### PR TITLE
ci: verify OMP host compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Node 22 unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Set up Node.js 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22.x'
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  host-smoke:
+    name: OMP ${{ matrix.omp-version }} host smoke
+    needs: unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        omp-version: ['17.0.3', 'latest']
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Set up Node.js 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22.x'
+          cache: npm
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - run: npm ci
+      - name: Install OMP host
+        env:
+          OMP_VERSION: ${{ matrix.omp-version }}
+        run: npm install --global "@oh-my-pi/pi-coding-agent@${OMP_VERSION}"
+      - name: Install packed gsd-omp
+        run: |
+          package_tarball="$(npm pack --silent --ignore-scripts)"
+          npm install --global "./${package_tarball}"
+      - name: Exercise isolated OMP host
+        env:
+          GSD_OMP_BIN: gsd-omp
+          OMP_VERSION: ${{ matrix.omp-version }}
+        run: node scripts/host-smoke.cjs

--- a/scripts/host-smoke.cjs
+++ b/scripts/host-smoke.cjs
@@ -1,0 +1,113 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const repositoryRoot = path.resolve(__dirname, '..');
+const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-omp-host-smoke-'));
+const ompBin = process.env.OMP_BIN || 'omp';
+const gsdOmpBin = process.env.GSD_OMP_BIN;
+const hostEnvironment = {
+  ...process.env,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY || 'not-a-real-key',
+  PI_CODING_AGENT_DIR: runtimeRoot,
+};
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    env: hostEnvironment,
+    timeout: 120_000,
+    ...options,
+  });
+  if (result.error) throw result.error;
+  assert.equal(
+    result.status,
+    0,
+    `${command} ${args.join(' ')} exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return result.stdout;
+}
+
+function runPlugin(args) {
+  return gsdOmpBin
+    ? run(gsdOmpBin, args)
+    : run(process.execPath, [path.join(repositoryRoot, 'bin', 'gsd-omp.cjs'), ...args]);
+}
+
+function parseJson(output, label) {
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    throw new Error(`${label} did not emit JSON: ${error.message}\n${output}`);
+  }
+}
+
+function parseRpcFrames(output) {
+  return output
+    .split(/\r?\n/)
+    .filter((line) => line.trim())
+    .map((line) => parseJson(line, 'OMP RPC'));
+}
+
+try {
+  const install = parseJson(runPlugin(['install', '--root', runtimeRoot, '--json']), 'gsd-omp install');
+  assert.equal(install.protocolVersion, 1);
+  assert.equal(install.coreVersion, '1.7.0');
+  assert.ok(install.installed > 50, `expected projected artifacts, received ${install.installed}`);
+
+  const doctor = parseJson(runPlugin(['doctor', '--root', runtimeRoot, '--json']), 'gsd-omp doctor');
+  assert.equal(doctor.ok, true);
+  assert.equal(doctor.profile, 'programmatic-cli');
+  assert.deepEqual(doctor.missing, []);
+  assert.deepEqual(doctor.modified, []);
+
+  const descriptor = parseJson(runPlugin(['descriptor', '--json']), 'gsd-omp descriptor');
+  assert.equal(descriptor.protocolVersion, 1);
+  assert.equal(descriptor.profile, 'programmatic-cli');
+  assert.equal(descriptor.axes.transport, 'native-extension');
+  assert.equal(descriptor.axes.runtime, 'bun');
+
+  const modelCatalog = parseJson(run(ompBin, ['models', 'openai', '--json']), 'OMP model catalog');
+  const model = modelCatalog.models?.find((candidate) => candidate.selector);
+  assert.ok(model, 'OMP did not expose a selectable OpenAI model for the host smoke test');
+
+  const rpcOutput = run(
+    ompBin,
+    [
+      '--mode', 'rpc',
+      '--no-session',
+      '--model', model.selector,
+      '--cwd', repositoryRoot,
+    ],
+    { input: '' },
+  );
+  const frames = parseRpcFrames(rpcOutput);
+  assert.equal(frames.some((frame) => frame.type === 'extension_error'), false, 'OMP reported an extension error');
+  assert.equal(frames.some((frame) => frame.type === 'ready'), true, 'OMP did not reach the ready state');
+
+  const commandUpdate = frames.find((frame) => frame.type === 'available_commands_update');
+  assert.ok(commandUpdate, 'OMP did not publish its available command surface');
+  const extensionCommands = new Map(
+    commandUpdate.commands
+      .filter((command) => command.source === 'extension')
+      .map((command) => [command.name, command]),
+  );
+  for (const command of ['gsd', 'gsd-next', 'gsd-plan-phase', 'gsd-status']) {
+    assert.ok(extensionCommands.has(command), `OMP did not load extension command /${command}`);
+  }
+
+  const uninstall = parseJson(runPlugin(['uninstall', '--root', runtimeRoot, '--json']), 'gsd-omp uninstall');
+  assert.equal(uninstall.removed, install.installed);
+  assert.deepEqual(uninstall.skipped, []);
+
+  process.stdout.write(
+    `ok host-smoke: OMP ${process.env.OMP_VERSION || 'local'} loaded ${extensionCommands.size} GSD extension commands\n`,
+  );
+} finally {
+  fs.rmSync(runtimeRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- add a least-privilege GitHub Actions workflow with immutable action SHAs
- run Node.js 22 syntax and unit checks on pushes and pull requests
- pack and globally install `gsd-omp`, then exercise it in an isolated real OMP RPC host
- cover the release baseline (`17.0.3`) and rolling `latest` OMP, including a weekly compatibility run
- verify install, doctor, descriptor, extension command discovery, and uninstall without making a model request

## Verification

- `npm run lint`
- `npm test` — 15 passing
- baseline host smoke with OMP `17.0.3`
- packed-artifact host smoke with OMP `17.0.6`
- workflow YAML parse

The smoke uses a non-secret placeholder API key only to let OMP initialize its local model catalog; stdin closes after startup, so no provider request is made.
