### PR TITLE
fix: harden OMP extension lifecycle

### DIFF
--- a/scripts/host-smoke.cjs
+++ b/scripts/host-smoke.cjs
@@ -76,6 +76,7 @@ try {
   const model = modelCatalog.models?.find((candidate) => candidate.selector);
   assert.ok(model, 'OMP did not expose a selectable OpenAI model for the host smoke test');
 
+  const stateRequestId = 'gsd-omp-host-smoke-state';
   const rpcOutput = run(
     ompBin,
     [
@@ -84,7 +85,7 @@ try {
       '--model', model.selector,
       '--cwd', repositoryRoot,
     ],
-    { input: '' },
+    { input: `${JSON.stringify({ id: stateRequestId, type: 'get_state' })}\n` },
   );
   const frames = parseRpcFrames(rpcOutput);
   assert.equal(frames.some((frame) => frame.type === 'extension_error'), false, 'OMP reported an extension error');
@@ -101,12 +102,19 @@ try {
     assert.ok(extensionCommands.has(command), `OMP did not load extension command /${command}`);
   }
 
+  const stateResponse = frames.find((frame) => frame.id === stateRequestId);
+  assert.equal(stateResponse?.success, true, 'OMP did not return its RPC session state');
+  const systemPrompt = Array.isArray(stateResponse.data?.systemPrompt)
+    ? stateResponse.data.systemPrompt.join('\n')
+    : String(stateResponse.data?.systemPrompt || '');
+  assert.match(systemPrompt, /xd:\/\/gsd_invoke\b/, 'OMP did not mount the gsd_invoke xdev tool');
+
   const uninstall = parseJson(runPlugin(['uninstall', '--root', runtimeRoot, '--json']), 'gsd-omp uninstall');
   assert.equal(uninstall.removed, install.installed);
   assert.deepEqual(uninstall.skipped, []);
 
   process.stdout.write(
-    `ok host-smoke: OMP ${process.env.OMP_VERSION || 'local'} loaded ${extensionCommands.size} GSD extension commands\n`,
+    `ok host-smoke: OMP ${process.env.OMP_VERSION || 'local'} loaded ${extensionCommands.size} GSD extension commands and xd://gsd_invoke\n`,
   );
 } finally {
   fs.rmSync(runtimeRoot, { recursive: true, force: true });

--- a/src/extension.cjs
+++ b/src/extension.cjs
@@ -3616,7 +3616,7 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
         return `GSD · ${activity}${detail}`;
       };
       onUpdate?.({ content: [{ type: 'text', text: progressMessage() }] });
-      const timer = onUpdate ? setInterval(() => onUpdate({ content: [{ type: 'text', text: progressMessage() }] }), 250) : null;
+      const timer = onUpdate ? ctx.setInterval(() => onUpdate({ content: [{ type: 'text', text: progressMessage() }] }), 250) : null;
       try {
         const result = await invokeAsync({ ...params, cwd: ctx.cwd, signal });
         return {
@@ -3624,7 +3624,7 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
           details: result,
         };
       } finally {
-        if (timer) clearInterval(timer);
+        if (timer) ctx.clearTimer(timer);
       }
     }
   });

--- a/test/extension.test.cjs
+++ b/test/extension.test.cjs
@@ -55,3 +55,41 @@ function mockPi() {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('uses OMP-managed timers for gsd_invoke progress updates', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-omp-managed-timer-'));
+  try {
+    const pi = mockPi();
+    extension(pi, { runtime: 'omp', runtimeRoot: root });
+    const timer = {};
+    let scheduled;
+    let cleared;
+    let updates = 0;
+    const ctx = {
+      cwd: root,
+      setInterval(callback, milliseconds) {
+        scheduled = { callback, milliseconds };
+        return timer;
+      },
+      clearTimer(handle) {
+        cleared = handle;
+      },
+    };
+
+    const result = await pi.tools.get('gsd_invoke').execute(
+      'tool-call',
+      { family: 'query', subcommand: 'help', args: [] },
+      new AbortController().signal,
+      () => { updates += 1; },
+      ctx,
+    );
+
+    assert.equal(typeof scheduled.callback, 'function');
+    assert.equal(scheduled.milliseconds, 250);
+    assert.equal(cleared, timer);
+    assert.equal(updates, 1);
+    assert.equal(Array.isArray(result.content), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- route `gsd_invoke` progress updates through OMP-managed `ctx.setInterval` / `ctx.clearTimer`
- add a unit contract proving the managed timer is scheduled and cleared
- extend the real RPC host smoke to request session state and verify `xd://gsd_invoke` is mounted

## Why

OMP 17.0.5/17.0.6 documents managed extension timers as the safe lifecycle for containing callback failures and clearing background work on session shutdown. The same releases changed xdev/custom-tool routing, so the host smoke now protects the structured GSD tool surface as well as slash commands.

## Verification

- `npm run lint`
- `npm test` — 16 passing
- OMP `17.0.3` host smoke — 74 extension commands plus `xd://gsd_invoke`
- packed-artifact OMP `17.0.6` host smoke — 74 extension commands plus `xd://gsd_invoke`
