### PR TITLE
chore: release gsd-omp v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is third-party software. It is not endorsed, reviewed, or maintaine
 Install the released plugin globally, then project its managed extension, agents, and skills into OMP:
 
 ```bash
-npm install --global github:tchivs/gsd-omp#v1.0.0
+npm install --global github:tchivs/gsd-omp#v1.0.1
 gsd-omp install
 ```
 
@@ -59,7 +59,7 @@ gsd-omp descriptor
 
 ```bash
 gsd-omp uninstall
-npm install --global github:tchivs/gsd-omp#v1.0.0
+npm install --global github:tchivs/gsd-omp#v1.0.1
 gsd-omp install
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@
 全局安装已发布的插件，随后将其托管的扩展、agents 与 skills 投影到 OMP：
 
 ```bash
-npm install --global github:tchivs/gsd-omp#v1.0.0
+npm install --global github:tchivs/gsd-omp#v1.0.1
 gsd-omp install
 ```
 
@@ -60,7 +60,7 @@ gsd-omp descriptor
 
 ```bash
 gsd-omp uninstall
-npm install --global github:tchivs/gsd-omp#v1.0.0
+npm install --global github:tchivs/gsd-omp#v1.0.1
 gsd-omp install
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-omp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-omp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@opengsd/gsd-core": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-omp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Oh My Pi host plugin for the GSD Embeddable Orchestration System — extension bindings, slash-command surface, and Host-Integration SDK adapter for AI coding agents",
   "license": "MIT",
   "author": "tchivs",


### PR DESCRIPTION
## Summary

- bump `gsd-omp` to `1.0.1`
- update English and Simplified-Chinese install/upgrade commands to the new release tag
- carry the OMP-managed timer and `xd://gsd_invoke` compatibility hardening from #2 into the patch release

## Verification

- `npm ci`
- `npm run lint`
- `npm test` — 16 passing
- `npm pack --dry-run`
