### PR TITLE
ci: move setup-node to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Node.js 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22.x'
           cache: npm
@@ -45,7 +45,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Set up Node.js 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22.x'
           cache: npm


### PR DESCRIPTION
## Summary

- update the immutable `actions/setup-node` pin from v4 to v6
- remove GitHub Actions Node.js 20 runtime deprecation annotations
- keep the tested project runtime at Node.js 22

## Verification

- workflow YAML parses successfully
- `actions/setup-node@v6` declares `runs.using: node24`