### PR TITLE
docs: document OMP/GSD model routing contract (modelMode: passive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,32 @@ npm uninstall --global gsd-omp
 ```
 Modified managed files are preserved and reported. Pass `--force` only when they should be deleted.
 
+## Model routing
+
+OMP and GSD both have model concepts, but they operate at different granularity and the plugin deliberately does not bridge them:
+
+| | OMP | GSD |
+|---|---|---|
+| Switch surface | `/model <id> --provider <p>` | `.planning/config.json` `model_profile` + per-agent `tier` |
+| Granularity | **session-global** | **per-agent** (`gsd-planner` → heavy, `gsd-executor` → standard, …) |
+| When resolved | any time at runtime | install / config time |
+
+The plugin declares `modelMode: 'passive'`, meaning **OMP is the model authority and GSD defers**. This is intentional, not a gap:
+
+- `model-catalog.json` ships `runtimeTierDefaults['omp'] = {}` (empty), so `resolveTierEntry({runtime:'omp',…})` returns `null` and the request-level override path fails open.
+- Projected agent frontmatter does **not** write a `model:` field, letting OMP's native task dispatch use the current session model.
+- `buildBeforeProviderRequestHandler` (request-level model swap) is registered only for the legacy `pi` runtime, not OMP.
+
+### What actually controls the model in OMP
+
+- **To change the model:** use OMP's `/model`. This is the only effective lever — every GSD agent in the session runs on it.
+- **To change the GSD profile:** `/gsd-settings`. This affects GSD's internal agent → tier mapping, but **has no observable effect under OMP** because the omp tier map is empty.
+- `model_profile_overrides.omp` in `.planning/config.json` is a **silent no-op** under OMP. Setting it will not change behavior; do not rely on it.
+
+### Why no deeper bridging
+
+True per-agent routing (planner on a strong model, executor on a fast one) would require OMP's task-dispatch protocol to carry a per-agent `model` field, which is outside this plugin's scope. Filling the omp tier map with fixed IDs would also go stale the moment the user runs `/model`. `passive` is the honest contract.
+
 ## Locale
 
 The host CLI (`gsd-omp install|uninstall|doctor|descriptor`) and EoS bootstrap messages localize through the POSIX environment, resolved in this order:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -161,6 +161,32 @@ npm uninstall --global gsd-omp
 
 被修改的托管文件会被保留并报告。仅当确实要删除它们时，才传入 `--force`。
 
+## 模型路由
+
+OMP 与 GSD 都有模型概念,但二者粒度不同,本插件刻意不做桥接:
+
+| | OMP | GSD |
+|---|---|---|
+| 切换入口 | `/model <id> --provider <p>` | `.planning/config.json` 的 `model_profile` + 每 agent 的 `tier` |
+| 粒度 | **session 全局** | **per-agent**(`gsd-planner` → heavy、`gsd-executor` → standard、…) |
+| 解析时机 | 运行时随时 | install / 配置时 |
+
+插件声明 `modelMode: 'passive'`,即 **OMP 是模型权威,GSD 退让**。这是有意为之,不是缺失:
+
+- `model-catalog.json` 里 `runtimeTierDefaults['omp'] = {}`(空),因此 `resolveTierEntry({runtime:'omp',…})` 返回 `null`,request 级覆盖路径 fail-open。
+- 投影出的 agent frontmatter **不写** `model:` 字段,让 OMP 原生任务派发使用当前 session 模型。
+- `buildBeforeProviderRequestHandler`(request 级模型替换)只对遗留的 `pi` runtime 注册,不对 OMP 注册。
+
+### 在 OMP 下到底什么决定模型
+
+- **换模型:** 用 OMP 的 `/model`。这是唯一真正有效的杠杆 —— session 里所有 GSD agent 都跑在它上面。
+- **换 GSD profile:** `/gsd-settings`。这会影响 GSD 内部的 agent → tier 映射,但**在 OMP 下无可观察效果**,因为 omp tier map 是空的。
+- `.planning/config.json` 里的 `model_profile_overrides.omp` 在 OMP 下是**静默空操作**。设了也不会改变行为,不要依赖它。
+
+### 为什么不做更深的桥接
+
+真正的 per-agent 路由(planner 用强模型、executor 用快模型)需要 OMP 的 task-dispatch 协议携带 per-agent `model` 字段,这超出本插件职责。而用固定 model ID 填充 omp tier map,用户一跑 `/model` 就立刻陈旧。`passive` 是诚实的契约。
+
 ## 语言环境
 
 宿主 CLI（`gsd-omp install|uninstall|doctor|descriptor`）与 EoS 引导阶段的消息遵循 POSIX 环境变量，按以下顺序解析：


### PR DESCRIPTION
Explains why the plugin does not bridge OMP's session-global `/model` and GSD's per-agent profile+tier system.

## What this adds

A new **Model routing** section in both `README.md` and `README.zh-CN.md`, placed between Uninstall and Locale.

Content:
- Comparison table: OMP `/model` (session-global) vs GSD `model_profile` + per-agent `tier`
- The three intentional deferral points that make `modelMode: 'passive'` real:
  1. `runtimeTierDefaults['omp'] = {}` in model-catalog.json → `resolveTierEntry` returns null → fail-open
  2. Projected agent frontmatter does not write `model:` → OMP native task dispatch uses session model
  3. `buildBeforeProviderRequestHandler` registered only for the legacy `pi` runtime
- **Footgun flag:** `model_profile_overrides.omp` is a silent no-op under OMP — documented so users don't rely on it
- Why no deeper bridging: per-agent routing needs an OMP task-dispatch protocol field (out of scope); fixed IDs in the tier map would go stale on `/model`

## Why documentation, not code

`modelMode: 'passive'` + empty omp tier map is deliberate design, not a gap. The root cause is granularity mismatch (OMP session-global vs GSD per-agent), and the OMP task-dispatch protocol has no per-agent model field. `passive` is the honest contract. See [discussion in chat](#) for the full analysis of why options 2 (per-agent routing) and 3 (profile sync) are both wrong here.

## Verification
- `npm run lint` ✅
- Section structure: 1 H2 + 2 H3, 3-row table, EN/ZH parity verified
- No code changes