### PR TITLE
chore: bump @opengsd/gsd-core from 1.7.0 to 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Release](https://img.shields.io/github/v/release/tchivs/gsd-omp?logo=github&label=release)](https://github.com/tchivs/gsd-omp/releases)
 [![License: MIT](https://img.shields.io/github/license/tchivs/gsd-omp?color=blue)](./LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%E2%89%A522-339933?logo=node.js&logoColor=white)](https://nodejs.org)
-[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%89%A51.7.0-0066cc)](https://github.com/open-gsd/gsd-core)
+[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%89%A51.8.0-0066cc)](https://github.com/open-gsd/gsd-core)
 [![OMP EoS](https://img.shields.io/badge/OMP-EoS%20v1-6c31c4)](#eos-contract)
 [![Last Commit](https://img.shields.io/github/last-commit/tchivs/gsd-omp?logo=git&logoColor=white)](https://github.com/tchivs/gsd-omp/commits)
 [![Stars](https://img.shields.io/github/stars/tchivs/gsd-omp?style=social)](https://github.com/tchivs/gsd-omp/stargazers)
@@ -17,7 +17,7 @@ This project is third-party software. It is not endorsed, reviewed, or maintaine
 
 - Node.js 22 or newer
 - Oh My Pi with native ExtensionAPI support
-- GSD Core 1.7.0 or newer; installed automatically as this package's dependency
+- GSD Core 1.8.0 or newer; installed automatically as this package's dependency
 
 ## Install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 [![Release](https://img.shields.io/github/v/release/tchivs/gsd-omp?logo=github&label=release)](https://github.com/tchivs/gsd-omp/releases)
 [![License: MIT](https://img.shields.io/github/license/tchivs/gsd-omp?color=blue)](./LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%E2%89%A522-339933?logo=node.js&logoColor=white)](https://nodejs.org)
-[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%89%A51.7.0-0066cc)](https://github.com/open-gsd/gsd-core)
+[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%89%A51.8.0-0066cc)](https://github.com/open-gsd/gsd-core)
 [![OMP EoS](https://img.shields.io/badge/OMP-EoS%20v1-6c31c4)](#eos-契约)
 [![Last Commit](https://img.shields.io/github/last-commit/tchivs/gsd-omp?logo=git&logoColor=white)](https://github.com/tchivs/gsd-omp/commits)
 [![Stars](https://img.shields.io/github/stars/tchivs/gsd-omp?style=social)](https://github.com/tchivs/gsd-omp/stargazers)
@@ -18,7 +18,7 @@
 
 - Node.js 22 或更高版本
 - 启用原生 ExtensionAPI 的 Oh My Pi
-- GSD Core 1.7.0 或更高版本；作为本包依赖自动安装
+- GSD Core 1.8.0 或更高版本；作为本包依赖自动安装
 
 ## 安装
 

--- a/bin/gsd-omp.cjs
+++ b/bin/gsd-omp.cjs
@@ -74,7 +74,7 @@ function removeEmptyParents(start, stop) {
 function assertSupportedCore(coreRoot) {
   const corePackage = JSON.parse(fs.readFileSync(path.join(coreRoot, 'package.json'), 'utf8'));
   const match = String(corePackage.version || '').match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match || Number(match[1]) < 1 || (Number(match[1]) === 1 && Number(match[2]) < 7)) {
+  if (!match || Number(match[1]) < 1 || (Number(match[1]) === 1 && Number(match[2]) < 8)) {
     throw new Error(t('cli.error.unsupportedCore', { version: corePackage.version || 'unknown' }));
   }
   return corePackage.version;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@opengsd/gsd-core": "^1.7.0"
+        "@opengsd/gsd-core": "^1.8.0"
       },
       "bin": {
         "gsd-omp": "bin/gsd-omp.cjs"
       },
       "engines": {
-        "gsd": ">=1.7.0",
+        "gsd": ">=1.8.0",
         "node": ">=22.0.0"
       }
     },
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@opengsd/gsd-core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@opengsd/gsd-core/-/gsd-core-1.7.0.tgz",
-      "integrity": "sha512-pWQTelxXYMBtsWNCHO9zNxUB+uWVmljjQvWB6Nyb9mk38GKfRxa+IZt5woS1gJwWQjEsiNjlgDyh6qXEaxxxhw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opengsd/gsd-core/-/gsd-core-1.8.0.tgz",
+      "integrity": "sha512-xgz8Er1/uAaWvIkTXBuNNbVO3d113H9dJUysHSz9yP9wCf57AEs7dLgWdaatPeLVDYTbtJEugkxSUBIscEsCrg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "prepack": "npm run lint && npm test"
   },
   "dependencies": {
-    "@opengsd/gsd-core": "^1.7.0"
+    "@opengsd/gsd-core": "^1.8.0"
   },
   "engines": {
     "node": ">=22.0.0",
-    "gsd": ">=1.7.0"
+    "gsd": ">=1.8.0"
   },
   "repository": {
     "type": "git",

--- a/scripts/host-smoke.cjs
+++ b/scripts/host-smoke.cjs
@@ -7,6 +7,8 @@ const os = require('node:os');
 const path = require('node:path');
 
 const repositoryRoot = path.resolve(__dirname, '..');
+
+const gsdCoreVersion = require('@opengsd/gsd-core/package.json').version;
 const runtimeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-omp-host-smoke-'));
 const ompBin = process.env.OMP_BIN || 'omp';
 const gsdOmpBin = process.env.GSD_OMP_BIN;
@@ -57,7 +59,7 @@ function parseRpcFrames(output) {
 try {
   const install = parseJson(runPlugin(['install', '--root', runtimeRoot, '--json']), 'gsd-omp install');
   assert.equal(install.protocolVersion, 1);
-  assert.equal(install.coreVersion, '1.7.0');
+  assert.ok(install.coreVersion === gsdCoreVersion, `coreVersion ${install.coreVersion} !== expected ${gsdCoreVersion}`);
   assert.ok(install.installed > 50, `expected projected artifacts, received ${install.installed}`);
 
   const doctor = parseJson(runPlugin(['doctor', '--root', runtimeRoot, '--json']), 'gsd-omp doctor');

--- a/src/extension.cjs
+++ b/src/extension.cjs
@@ -29,7 +29,7 @@ function resolveEngineRoot(startDir) {
       if (parent === dir) break;
       dir = parent;
     }
-    throw new Error('gsd-omp: @opengsd/gsd-core >=1.7.0 is required');
+    throw new Error('gsd-omp: @opengsd/gsd-core >=1.8.0 is required');
   }
 }
 
@@ -554,7 +554,7 @@ module.exports = function gsdPiExtension(pi, options = {}) {
         if (parent === dir) break;
         dir = parent;
       }
-      throw new Error('gsd-omp: @opengsd/gsd-core >=1.7.0 is required');
+      throw new Error('gsd-omp: @opengsd/gsd-core >=1.8.0 is required');
     }
   }
 

--- a/src/locales/en.cjs
+++ b/src/locales/en.cjs
@@ -10,7 +10,7 @@ module.exports = {
   'cli.error.unknownArgument': 'Unknown argument: {arg}',
   'cli.error.rootRequiresPath': '--root requires a path',
   'cli.error.cannotReadManifest': 'Cannot read {path}: {message}',
-  'cli.error.unsupportedCore': 'gsd-omp requires @opengsd/gsd-core >=1.7.0; found {version}',
+  'cli.error.unsupportedCore': 'gsd-omp requires @opengsd/gsd-core >=1.8.0; found {version}',
   'cli.error.refusingOverwrite': 'Refusing to overwrite unmanaged or modified file: {path} (rerun with --force to replace GSD-owned projections)',
 
   'eos.error.unexpectedProfile': 'gsd-omp: EoS negotiation produced {profile}, expected programmatic-cli',

--- a/src/locales/zh-CN.cjs
+++ b/src/locales/zh-CN.cjs
@@ -10,7 +10,7 @@ module.exports = {
   'cli.error.unknownArgument': '未知参数：{arg}',
   'cli.error.rootRequiresPath': '--root 需要一个路径',
   'cli.error.cannotReadManifest': '无法读取 {path}：{message}',
-  'cli.error.unsupportedCore': 'gsd-omp 需要 @opengsd/gsd-core >=1.7.0；当前版本 {version}',
+  'cli.error.unsupportedCore': 'gsd-omp 需要 @opengsd/gsd-core >=1.8.0；当前版本 {version}',
   'cli.error.refusingOverwrite': '拒绝覆盖未托管或已本地修改的文件：{path}（加 --force 可替换 GSD 托管的投影文件）',
 
   'eos.error.unexpectedProfile': 'gsd-omp：EoS 协商得到 {profile}，应为 programmatic-cli',


### PR DESCRIPTION
Bumps the gsd-core dependency floor across all tracked surfaces.

## Changes
- `package.json`: dependency `^1.7.0` → `^1.8.0`, `engines.gsd` `>=1.7.0` → `>=1.8.0`
- `bin/gsd-omp.cjs`: `assertSupportedCore` minimum 1.7 → 1.8
- `src/extension.cjs`: two `resolveEngineRoot` error messages 1.7.0 → 1.8.0
- `src/locales/{en,zh-CN}.cjs`: `unsupportedCore` message 1.7.0 → 1.8.0
- `README.md` + `README.zh-CN.md`: GSD Core badge + requirement text
- `package-lock.json`: gsd-core 1.7.0 → 1.8.0

## Verification
- `npm run lint` ✅
- `npm test` → 17/17 pass ✅
- `gsd-omp install --force` + `gsd-omp doctor` → `"ok": true`, `coreVersion: 1.8.0`