### PR TITLE
fix: stop detached GSD tasks leaking into /gsd-next's active count

### DIFF
--- a/src/extension.cjs
+++ b/src/extension.cjs
@@ -490,6 +490,40 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     if (activeTaskIds?.size === 0) activeGsdTaskIds.delete(projectPath);
     return true;
   }
+  // Detached GSD tasks (OMP's execute/plan dispatch) return at spawn time with
+  // TaskToolDetails.async = { state: 'running', jobId }. The request was tracked
+  // by task `name` (the agent registry id), but job-completion events key on
+  // `jobId` — a separate id space (OMP AsyncJob.jobId != agentId). Without
+  // bridging, every detached task leaks its name entry and /gsd-next is
+  // permanently blocked by a stale count. See open-gsd/gsd-omp task tracking.
+  function reconcileTaskSettlement(event, cwd) {
+    if (event?.toolName !== 'task' || event.isError || typeof event.toolCallId !== 'string') return;
+    const projectPath = path.resolve(cwd);
+    const taskCalls = activeGsdTaskIdsByCall.get(projectPath);
+    const trackedIds = taskCalls?.get(event.toolCallId);
+    if (!trackedIds?.length) return;
+    const taskIds = activeGsdTaskIds.get(projectPath);
+    const asyncInfo = event?.details?.async;
+    if (asyncInfo && asyncInfo.state === 'running' && typeof asyncInfo.jobId === 'string' && asyncInfo.jobId) {
+      // Spawn ack for a detached job: swap name -> jobId so the later job event
+      // (releaseSettledGsdTasks, keyed on jobId) can release it.
+      const jobId = asyncInfo.jobId;
+      for (const id of trackedIds) taskIds?.delete(id);
+      taskIds?.add(jobId);
+      taskCalls.set(event.toolCallId, [jobId]);
+      return;
+    }
+    // Synchronous completion backstop: final results present means the call is
+    // terminal. Gated on results[] so a detached spawn ack lacking async
+    // metadata is not cleared prematurely. (trackGsdTaskProgress already clears
+    // terminal progress entries; this cleans the call map too.)
+    const results = event?.details?.results;
+    if (!Array.isArray(results) || !results.length) return;
+    for (const id of trackedIds) taskIds?.delete(id);
+    taskCalls.delete(event.toolCallId);
+    if (taskCalls.size === 0) activeGsdTaskIdsByCall.delete(projectPath);
+    if (taskIds && taskIds.size === 0) activeGsdTaskIds.delete(projectPath);
+  }
 
   function nativeTaskActivityCount(cwd) {
     return activeGsdTaskIds.get(path.resolve(cwd))?.size || 0;
@@ -1836,17 +1870,21 @@ The user explicitly selected the GSD action below. Execute it now, end-to-end, i
     return launchNativeProgress(ctx, '--next');
   }
 
+  async function emitNativeTasksActive(ctx, count) {
+    const chinese = usesChinese(ctx.cwd);
+    await pi.sendMessage({
+      customType: 'gsd-native-tasks-active',
+      content: chinese
+        ? `OMP 中有 ${count} 个原生 GSD 任务正在运行。请使用任务与 Job 面板跟踪；任务结束后再推进下一步。`
+        : `${count} native GSD task${count === 1 ? ' is' : 's are'} running in OMP. Track it in the task and Job panels; advance after it settles.`,
+      display: true,
+    }, { triggerTurn: false });
+  }
+
   async function chooseNextAction(ctx, state) {
     const activeTaskCount = nativeTaskActivityCount(ctx.cwd);
     if (activeTaskCount > 0) {
-      const chinese = usesChinese(ctx.cwd);
-      await pi.sendMessage({
-        customType: 'gsd-native-tasks-active',
-        content: chinese
-          ? `OMP 中有 ${activeTaskCount} 个原生 GSD 任务正在运行。请使用任务与 Job 面板跟踪；任务结束后再推进下一步。`
-          : `${activeTaskCount} native GSD task${activeTaskCount === 1 ? ' is' : 's are'} running in OMP. Track it in the task and Job panels; advance after it settles.`,
-        display: true,
-      }, { triggerTurn: false });
+      await emitNativeTasksActive(ctx, activeTaskCount);
       return;
     }
     const recovery = nativeTaskRecovery(ctx.cwd);
@@ -3576,6 +3614,8 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
   pi.registerCommand('gsd-next', {
     description: 'Show or prepare the next localized GSD action.',
     handler: async (_input, ctx) => {
+      const activeTaskCount = nativeTaskActivityCount(ctx.cwd);
+      if (activeTaskCount > 0) return emitNativeTasksActive(ctx, activeTaskCount);
       const recovery = nativeTaskRecovery(ctx.cwd);
       const continuation = !recovery && readNextAction(ctx.cwd);
       if (continuation) {
@@ -3687,6 +3727,7 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
     releaseSettledGsdTasks(event, ctx.cwd);
     releaseFailedGsdTaskRequest(event, ctx.cwd);
     trackGsdTaskProgress(event, ctx.cwd);
+    reconcileTaskSettlement(event, ctx.cwd);
     const output = (event.content || [])
       .filter((chunk) => chunk.type === 'text')
       .map((chunk) => chunk.text)
@@ -3720,6 +3761,7 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
     extractNextAction,
     extractCheckpoint,
     extractTaskResults,
+    _nativeTaskActivityCount: nativeTaskActivityCount,
   };
 };
 

--- a/test/extension.test.cjs
+++ b/test/extension.test.cjs
@@ -93,3 +93,129 @@ test('uses OMP-managed timers for gsd_invoke progress updates', async () => {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+function gsdProjectRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-omp-task-track-'));
+  fs.mkdirSync(path.join(root, '.planning'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.planning', 'STATE.md'), '# State\n');
+  return root;
+}
+
+function taskSpawnCall(toolCallId, names) {
+  return {
+    toolName: 'task',
+    toolCallId,
+    input: {
+      context: 'phase execution',
+      tasks: names.map((name) => ({ name, agent: 'gsd-executor', task: 'do work' })),
+    },
+  };
+}
+
+test('detached GSD task releases its tracked id when the job settles (no stale count)', async () => {
+  // Regression: trackGsdTaskRequest keys on task `name` (agent registry id) but
+  // job-completion events key on `jobId` (AsyncJob.jobId != agentId). Without
+  // bridging at the spawn ack, every detached task leaked a name entry and
+  // /gsd-next was permanently blocked by a stale count.
+  const root = gsdProjectRoot();
+  try {
+    const pi = mockPi();
+    extension(pi, { runtime: 'omp', runtimeRoot: root });
+    const count = () => extension._internals._nativeTaskActivityCount(root);
+    const toolCall = pi.events.get('tool_call');
+    const toolResult = pi.events.get('tool_result');
+    const ctx = { cwd: root };
+
+    await toolCall(taskSpawnCall('call_1', ['Phase1Plan01Executor', 'Phase1Plan02Executor']), ctx);
+    assert.equal(count(), 2, 'two names tracked at spawn');
+
+    await toolResult({
+      toolName: 'task', toolCallId: 'call_1', isError: false, content: [],
+      details: {
+        async: { state: 'running', jobId: 'job_1', type: 'task' },
+        progress: [
+          { id: 'Phase1Plan01Executor', agent: 'gsd-executor', status: 'running' },
+          { id: 'Phase1Plan02Executor', agent: 'gsd-executor', status: 'running' },
+        ],
+      },
+    }, ctx);
+    assert.equal(count(), 1, 'spawn ack swaps two names -> one jobId');
+
+    await toolResult({
+      toolName: 'job', toolCallId: 'call_2', isError: false, content: [],
+      details: { jobs: [{ id: 'job_1', type: 'task', status: 'completed', label: 'p1', durationMs: 1 }] },
+    }, ctx);
+    assert.equal(count(), 0, 'job completion releases the bridged jobId');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('synchronous GSD task releases on terminal tool_result', async () => {
+  const root = gsdProjectRoot();
+  try {
+    const pi = mockPi();
+    extension(pi, { runtime: 'omp', runtimeRoot: root });
+    const count = () => extension._internals._nativeTaskActivityCount(root);
+    const ctx = { cwd: root };
+
+    await pi.events.get('tool_call')(taskSpawnCall('call_s', ['Phase1Plan03Executor']), ctx);
+    assert.equal(count(), 1, 'name tracked at spawn');
+
+    await pi.events.get('tool_result')({
+      toolName: 'task', toolCallId: 'call_s', isError: false, content: [],
+      details: { results: [{ id: 'Phase1Plan03Executor', agent: 'gsd-executor', exitCode: 0, output: '' }] },
+    }, ctx);
+    assert.equal(count(), 0, 'sync completion clears the tracked name');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('failed GSD task request releases tracked names', async () => {
+  const root = gsdProjectRoot();
+  try {
+    const pi = mockPi();
+    extension(pi, { runtime: 'omp', runtimeRoot: root });
+    const count = () => extension._internals._nativeTaskActivityCount(root);
+    const ctx = { cwd: root };
+
+    await pi.events.get('tool_call')(taskSpawnCall('call_f', ['Phase1Plan04Executor']), ctx);
+    assert.equal(count(), 1);
+
+    await pi.events.get('tool_result')({
+      toolName: 'task', toolCallId: 'call_f', isError: true, content: [],
+    }, ctx);
+    assert.equal(count(), 0, 'errored spawn releases the tracked name');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('gsd-next does not advance while a native GSD task is still running', async () => {
+  // /gsd-next must check native task activity BEFORE dispatching a saved
+  // continuation, mirroring chooseNextAction. Otherwise it spawns the next
+  // phase on top of in-flight executor tasks.
+  const root = gsdProjectRoot();
+  fs.writeFileSync(
+    path.join(root, '.planning', '.omp-next-action.json'),
+    JSON.stringify({ command: 'gsd-plan-phase 2', label: 'Plan Phase 2' }),
+  );
+  try {
+    const sent = [];
+    const pi = mockPi();
+    pi.sendMessage = async (message) => { sent.push(message); };
+    extension(pi, { runtime: 'omp', runtimeRoot: root });
+    const ctx = { cwd: root, hasUI: true, ui: {} };
+
+    await pi.events.get('tool_call')(taskSpawnCall('call_run', ['Phase1Plan05Executor']), ctx);
+    assert.equal(extension._internals._nativeTaskActivityCount(root), 1, 'task tracked');
+
+    await pi.commands.get('gsd-next').handler({}, ctx);
+    assert.equal(sent.length, 1, 'gsd-next emitted exactly one message');
+    assert.equal(sent[0].customType, 'gsd-native-tasks-active',
+      'gsd-next reports active tasks instead of dispatching the saved continuation');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

`/gsd-next` gets permanently blocked by a stale `N native GSD tasks running` notice — even after the plan/execute work finished. The active-task count never returns to zero.

## Root cause

Detached GSD tasks (OMP's plan/execute dispatch model) return at **spawn time** with `TaskToolDetails.async = { state: 'running', jobId }` — the subagent keeps running as a background job while the orchestrator polls it.

The in-flight set was keyed on the task `name` (the agent registry id — `trackGsdTaskRequest`), but **job-completion events key on `jobId`**, a separate id space:

| Source | Key | Where |
|---|---|---|
| `trackGsdTaskRequest` (spawn) | task `name` (agent registry id) | extension.cjs |
| `releaseSettledGsdTasks` (job events) | `job.id` (jobId) | extension.cjs |
| OMP `AsyncJob` | `jobId != agentId` (documented) | job-manager.d.ts:21-25 |
| OMP `JobSnapshot` | `id` only, no `agentId` | hub/types.d.ts:27-37 |

So every successfully dispatched detached task leaked a `name` entry — `nativeTaskActivityCount` never hit zero and `/gsd-next` stayed blocked.

## Fix

**`reconcileTaskSettlement`** (new) bridges the two id spaces on the spawn ack: it swaps the tracked `name`(s) for the `jobId`, so the later `job` event (`releaseSettledGsdTasks`, keyed on `jobId`) can release it. A `results[]`-gated backstop covers synchronous completion without prematurely clearing a detached spawn that lacks async metadata.

Also closes a related gap: the `/gsd-next` command handler checked a saved continuation **before** task activity and could dispatch the next phase on top of in-flight tasks. It now mirrors `chooseNextAction` and the status summaries (guard first). The duplicated message was extracted into `emitNativeTasksActive`.

## Verification

- `npm run lint` ✅
- `npm test` → **21/21 pass** (4 new regression tests)
- `gsd-omp install --force` + `doctor` → `ok: true`
- `scripts/host-smoke.cjs` ✅

New tests:
- `detached GSD task releases its tracked id when the job settles` — the core regression (count 2 → 1 on spawn-ack name→jobId swap → 0 on job completion)
- `synchronous GSD task releases on terminal tool_result`
- `failed GSD task request releases tracked names`
- `gsd-next does not advance while a native GSD task is still running`

## Note for users hitting this now

The leaked entries live in the extension process's in-memory map. After installing this fix, **reload OMP** (restart the session) to pick up the new code and clear the stale count.