### PR TITLE
chore: release gsd-omp v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is third-party software. It is not endorsed, reviewed, or maintaine
 Install the released plugin globally, then project its managed extension, agents, and skills into OMP:
 
 ```bash
-npm install --global github:tchivs/gsd-omp#v1.0.1
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.2.tar.gz
 gsd-omp install
 ```
 
@@ -139,7 +139,7 @@ gsd-omp descriptor
 
 ```bash
 gsd-omp uninstall
-npm install --global github:tchivs/gsd-omp#v1.0.1
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.2.tar.gz
 gsd-omp install
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@
 全局安装已发布的插件，随后将其托管的扩展、agents 与 skills 投影到 OMP：
 
 ```bash
-npm install --global github:tchivs/gsd-omp#v1.0.1
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.2.tar.gz
 gsd-omp install
 ```
 
@@ -140,7 +140,7 @@ gsd-omp descriptor
 
 ```bash
 gsd-omp uninstall
-npm install --global github:tchivs/gsd-omp#v1.0.1
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.2.tar.gz
 gsd-omp install
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-omp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-omp",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@opengsd/gsd-core": "^1.9.1"
@@ -598,7 +598,7 @@
       }
     },
     "node_modules/dunder-proto": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
@@ -627,7 +627,7 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
@@ -877,7 +877,7 @@
       }
     },
     "node_modules/get-proto": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
@@ -1369,7 +1369,7 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
@@ -1385,7 +1385,7 @@
       }
     },
     "node_modules/side-channel-map": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
@@ -1431,7 +1431,7 @@
       }
     },
     "node_modules/toidentifier": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-omp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Oh My Pi host plugin for the GSD Embeddable Orchestration System — extension bindings, slash-command surface, and Host-Integration SDK adapter for AI coding agents",
   "license": "MIT",
   "author": "tchivs",

--- a/test/release-metadata.test.cjs
+++ b/test/release-metadata.test.cjs
@@ -14,7 +14,7 @@ function readJson(file) {
 test('release metadata and README install commands use the package version', () => {
   const packageJson = readJson('package.json');
   const packageLock = readJson('package-lock.json');
-  const expectedInstall = `npm install --global github:tchivs/gsd-omp#v${packageJson.version}`;
+  const expectedInstall = `npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v${packageJson.version}.tar.gz`;
 
   assert.equal(packageLock.version, packageJson.version, 'package-lock.json version must match package.json');
   assert.equal(packageLock.packages[''].version, packageJson.version, 'lockfile root package version must match package.json');
@@ -22,7 +22,7 @@ test('release metadata and README install commands use the package version', () 
   for (const readme of ['README.md', 'README.zh-CN.md']) {
     const installCommands = fs.readFileSync(path.join(root, readme), 'utf8')
       .split(/\r?\n/)
-      .filter((line) => line.startsWith('npm install --global github:tchivs/gsd-omp#'));
+      .filter((line) => line.startsWith('npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v'));
 
     assert.deepEqual(
       installCommands,


### PR DESCRIPTION
## Summary

- bump `gsd-omp` to `1.0.2`
- switch install/upgrade commands to the GitHub **tarball URL** — the `github:` git shorthand installs as a dangling symlink on npm 11 (`node_modules/gsd-omp → ~/.npm/_cacache/tmp/git-cloneXXX`, then npm deletes the clone), leaving `gsd-omp: command not found`
- update release-metadata test to enforce the tarball command

## Included since v1.0.1

- #8 — stop detached GSD tasks leaking into /gsd-next's active count
- #10 — clean stale OMP task results on milestone completion
- #11 — adapt EoS axes + execute contract for gsd-core 1.9

## Verification

- `npm test` — 21 passing
- `npm pack --dry-run` — gsd-omp-1.0.2.tgz, 12 files
- tarball install verified in a temp prefix: `gsd-omp install` completes (106 files, core 1.9.1)