### PR TITLE
fix: point GSD_AGENTS_DIR at OMP agents (research/roadmap agents unavailable)

### DIFF
--- a/src/extension.cjs
+++ b/src/extension.cjs
@@ -302,6 +302,7 @@ module.exports = function gsdPiExtension(pi, options = {}) {
 
   const fs = require('node:fs');
   const path = require('node:path');
+  const os = require('node:os');
   const advisedFiles = new Set();
   const activeGsdTaskIds = new Map();
   const activeGsdTaskIdsByCall = new Map();
@@ -598,6 +599,15 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     path.join(ENGINE_ROOT, 'bin', 'gsd-tools.cjs'),
   ].find(fs.existsSync);
 
+  // OMP's global config dir (~/.omp/agent) is not a registered gsd-core runtime
+  // (registry has `pi`, not `omp`), so gsd-core's agent-install check resolves
+  // the agents dir to the Claude fallback (~/.claude/agents) and reports every
+  // GSD agent missing. Point the check at the plugin's real projection
+  // (~/.omp/agent/agents) so init.progress / init.new-project stop warning
+  // about unavailable research/roadmap agents.
+  const agentsDir = process.env.GSD_AGENTS_DIR || path.join(options.runtimeRoot || path.join(os.homedir(), '.omp', 'agent'), 'agents');
+  if (!process.env.GSD_AGENTS_DIR) process.env.GSD_AGENTS_DIR = agentsDir;
+
   function parseCommandLine(input) {
     const tokens = String(input || '').match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
     return tokens.map((token) => {
@@ -613,7 +623,7 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     const cliArgs = [CLI_PATH, family, subcommand, ...args];
     if (raw) cliArgs.push('--raw');
     return new Promise((resolve) => {
-      const child = spawn(process.execPath, cliArgs, { cwd, env: { ...process.env, GSD_RUNTIME: 'omp' }, stdio: ['ignore', 'pipe', 'pipe'] });
+      const child = spawn(process.execPath, cliArgs, { cwd, env: { ...process.env, GSD_RUNTIME: 'omp', GSD_AGENTS_DIR: agentsDir }, stdio: ['ignore', 'pipe', 'pipe'] });
       let stdout = '';
       let stderr = '';
       let cancelled = false;
@@ -3056,7 +3066,7 @@ Execute the gsd-progress workflow${mode} end-to-end.
 OMP progress contract:
 - For \`--next\`, delegate all routing to the canonical progress workflow. Do not re-derive phase routing in this adapter or bypass its Gates 1–3 and Route 0 incomplete-phase invariant.
 - Preserve the workflow's state inspection, safety gates, routing, and user-interaction rules. The native command is an entry point, not a replacement workflow.
-- Bind the workflow's \`gsd_run\` helper directly to \`${runtimeTools}\`, set \`GSD_RUNTIME=omp\` on every invocation, and use it for every GSD query. Never invoke bare \`gsd-tools\` or \`gsd-tools.cjs\` through \`PATH\`; another runtime installation may own that executable.
+- Bind the workflow's \`gsd_run\` helper directly to \`${runtimeTools}\`, set \`GSD_RUNTIME=omp\` and \`GSD_AGENTS_DIR=${agentsDir}\` on every invocation, and use it for every GSD query. Never invoke bare \`gsd-tools\` or \`gsd-tools.cjs\` through \`PATH\`; another runtime installation may own that executable.
 - Treat \`.planning/.continue-here.md\` as optional: probe its existence before any Read. A missing file passes Gate 1 and must not emit a tool error.
 - This message activates the \`gsd-progress\` skill workflow, not a \`gsd-tools\` CLI subcommand. Read \`skill://gsd-progress\`, then execute its selected workflow in this turn.
 - Do not call \`gsd_invoke\` to run this workflow. In particular, \`family: "gsd"\` is invalid; \`/gsd-progress\` is a native workflow entry point, not a \`gsd-tools\` family.

--- a/src/projection.cjs
+++ b/src/projection.cjs
@@ -86,7 +86,8 @@ function projectAgent(content, sourcePath, context) {
 
 function runtimeCliBlock(coreRoot) {
   const cliPath = toPosix(path.join(coreRoot, 'gsd-core', 'bin', 'gsd-tools.cjs'));
-  return `<omp_runtime_cli>\n**OMP runtime CLI:** \`${cliPath}\` is the authoritative GSD CLI for this plugin. Run it with \`GSD_RUNTIME=omp\`; do not dispatch a different runtime's bare \`gsd-tools\` executable. OMP owns model routing, approvals, native tasks, and isolation.\n</omp_runtime_cli>`;
+  return `<omp_runtime_cli>\n**OMP runtime CLI:** \`${cliPath}\` is the authoritative GSD CLI for this plugin. Run it with \`GSD_RUNTIME=omp\`. OMP owns model routing, approvals, native tasks, and isolation.\n\n**Agents on OMP:** GSD's \`init.progress\`/\`init.new-project\` agent check (\`.planning/agents_installed\`) resolves the agents directory from the runtime home. OMP's global config dir is not a registered gsd-core runtime, so the check falls back to \`~/.claude/agents\` and reports all GSD agents missing even though the plugin projects them under \`~/.omp/agent/agents\`. Point the check at the real install by exporting \`GSD_AGENTS_DIR\` (e.g. \`~/.omp/agent/agents\`) or by creating a symlink \`~/.claude/agents -> ~/.omp/agent/agents\`; the workflow must be launched fresh after either change. Do not reinstall the plugin.
+</omp_runtime_cli>`;
 }
 
 function projectSkill(name, content, context) {

--- a/test/extension.test.cjs
+++ b/test/extension.test.cjs
@@ -56,6 +56,30 @@ function mockPi() {
   }
 });
 
+ test('points GSD_AGENTS_DIR at the OMP agents projection so the gsd-core agent check is not a false negative', () => {
+  // gsd-core's checkAgentsInstalled('omp') resolves the agents dir from the
+  // runtime home; 'omp' is not a registered runtime, so it falls back to
+  // ~/.claude/agents and reports every GSD agent missing. The extension must
+  // export GSD_AGENTS_DIR = <runtimeRoot>/agents so init.progress /
+  // init.new-project see the projected agents (research/roadmap etc.).
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-omp-agents-'));
+  const prior = process.env.GSD_AGENTS_DIR;
+  try {
+    delete process.env.GSD_AGENTS_DIR;
+    const pi = mockPi();
+    extension(pi, { runtime: 'omp', runtimeRoot: root });
+    assert.equal(
+      process.env.GSD_AGENTS_DIR,
+      path.join(root, 'agents'),
+      'extension must export GSD_AGENTS_DIR pointing at its projected agents dir',
+    );
+  } finally {
+    if (prior === undefined) delete process.env.GSD_AGENTS_DIR;
+    else process.env.GSD_AGENTS_DIR = prior;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('uses OMP-managed timers for gsd_invoke progress updates', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-omp-managed-timer-'));
   try {


### PR DESCRIPTION
## Problem\n\n`⚠️ 未安装 GSD 专用 agents：研究与路线图代理不可用` appears even after `gsd-omp install` succeeds.\n\n**Root cause:** gsd-core's `checkAgentsInstalled('omp')` resolves the agents dir via `getGlobalConfigDir('omp')`. `omp` is not a registered runtime in gsd-core's capability registry (only `pi` is), so it falls back to `~/.claude/agents` and reports all 34 GSD agents missing. The plugin actually projects the agents into `~/.omp/agent/agents`.\n\n## Fix\n\n- `src/extension.cjs`: export `GSD_AGENTS_DIR=<runtimeRoot>/agents` (the first priority in gsd-core's `getAgentsDir()`) at extension load and pass it on every `gsd-tools` spawn, so `init.progress` / `init.new-project` resolve the real agents dir instead of the Claude fallback.\n- `src/projection.cjs`: document the override in the projected skill CLI block for workflows run outside the extension.\n- `test/extension.test.cjs`: regression test asserting the env export.\n\n## Verification\n\n- Before: `checkAgentsInstalled('omp')` → `agents_dir: ~/.claude/agents`, `installed: false`, 34 missing\n- After (with `GSD_AGENTS_DIR`): `installed: true`, 0 missing\n- 22 tests passing