### PR TITLE
feat: add gsd-omp update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ gsd-omp descriptor
 ## Upgrade
 
 ```bash
+gsd-omp update
+```
+
+Checks GitHub for the latest release, installs it (npm global tarball install), and re-projects the managed extension, agents, and skills in one step. Restart OMP afterwards.
+
+> **GSD core version**: `gsd-omp update` upgrades the bundled gsd-core (it is this package's dependency). OMP's own `~/.omp/agent/gsd-core/` engine tree (currently 1.7.0-rc.6) is outside this plugin's management — the plugin resolves gsd-core from its own `node_modules`. To align the OMP-side engine with the plugin, use OMP's own update path (e.g. `omp update`).
+
+If the update check fails (offline, GitHub unreachable), fall back to the manual steps:
+
+```bash
 gsd-omp uninstall
 npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.3.tar.gz
 gsd-omp install

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -139,6 +139,16 @@ gsd-omp descriptor
 ## 升级
 
 ```bash
+gsd-omp update
+```
+
+检查 GitHub 上的最新 release，通过 npm 全局 tarball 安装新版本，并重新投影受管的 extension / agents / skills，一步完成。之后重启 OMP。
+
+> **GSD 核心版本**：`gsd-omp update` 会一起升级捆绑的 gsd-core（它是本包的依赖）。但 OMP 的 `~/.omp/agent/gsd-core/` 是 OMP 自带的引擎树（当前 1.7.0-rc.6），不在本插件管理范围内——插件从自身 `node_modules` 解析 gsd-core。若需要 OMP 侧引擎与插件一致，需用 OMP 自己的更新路径（如 `omp update`）。
+
+如果更新检查失败（离线、GitHub 不可达），回退到手动步骤：
+
+```bash
 gsd-omp uninstall
 npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.3.tar.gz
 gsd-omp install

--- a/bin/gsd-omp.cjs
+++ b/bin/gsd-omp.cjs
@@ -5,12 +5,15 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const Eos = require('../src/eos.cjs');
 const { buildProjectedArtifacts } = require('../src/projection.cjs');
 const packageJson = require('../package.json');
 const { t } = require('../src/locale.cjs');
 
 const MANIFEST_NAME = '.gsd-omp-manifest.json';
+const GITHUB_REPO = 'tchivs/gsd-omp';
+const RELEASE_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
 
 function sha256(content) {
   return crypto.createHash('sha256').update(content).digest('hex');
@@ -32,6 +35,47 @@ function parseArgs(argv) {
     } else throw new Error(t('cli.error.unknownArgument', { arg }));
   }
   return { command, root, force, json };
+}
+
+function githubLatestRelease() {
+  const res = spawnSync(
+    process.execPath,
+    ['-e', `fetch('${RELEASE_API}', { headers: { 'User-Agent': 'gsd-omp' } }).then(r => r.json()).then(j => process.stdout.write(JSON.stringify({ tag_name: j.tag_name, tarball_url: j.tarball_url }))).catch(() => process.exit(1))`],
+    { encoding: 'utf8', timeout: 15000 },
+  );
+  if (res.status !== 0) throw new Error(t('cli.error.updateCheckFailed'));
+  try {
+    return JSON.parse(res.stdout);
+  } catch {
+    throw new Error(t('cli.error.updateCheckFailed'));
+  }
+}
+
+function update({ root: rootOverride, force = false } = {}) {
+  const release = githubLatestRelease();
+  const latest = String(release.tag_name || '').replace(/^v/, '');
+  if (latest && latest === packageJson.version) {
+    return { upToDate: true, current: packageJson.version, root: runtimeRoot(rootOverride) };
+  }
+  const tarball = release.tarball_url || `https://github.com/${GITHUB_REPO}/archive/refs/tags/${release.tag_name || 'main'}.tar.gz`;
+  const npmArgs = ['install', '--global', '--prefix', globalPrefix(), tarball];
+  if (!process.env.GSD_OMP_UPDATE_SKIP_BIN) npmArgs.push('--no-save');
+  const res = spawnSync('npm', npmArgs, { encoding: 'utf8', stdio: 'inherit', timeout: 300000 });
+  if (res.status !== 0) throw new Error(t('cli.error.updateFailed'));
+  const installed = install({ root: rootOverride, force });
+  return {
+    updated: true,
+    from: packageJson.version,
+    to: latest || 'latest',
+    root: installed.root,
+    manifestPath: installed.manifestPath,
+    installed: installed.installed,
+  };
+}
+
+function globalPrefix() {
+  const res = spawnSync('npm', ['prefix', '--global'], { encoding: 'utf8' });
+  return (res.stdout || '').trim() || undefined;
 }
 
 function runtimeRoot(override) {
@@ -205,6 +249,7 @@ function main(argv = process.argv.slice(2)) {
   else if (options.command === 'uninstall') result = uninstall(options);
   else if (options.command === 'doctor') result = doctor(options);
   else if (options.command === 'descriptor') result = descriptor();
+  else if (options.command === 'update') result = update(options);
   else if (options.command === 'help' || options.command === '--help') {
     print(t('cli.usage'), false);
     return 0;
@@ -222,4 +267,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { descriptor, doctor, install, main, parseArgs, runtimeRoot, uninstall };
+module.exports = { descriptor, doctor, install, main, parseArgs, runtimeRoot, uninstall, update, githubLatestRelease, globalPrefix };

--- a/src/locales/en.cjs
+++ b/src/locales/en.cjs
@@ -4,7 +4,7 @@
 // Keys are flat and dotted by namespace. Add parallel keys to zh-CN.cjs.
 
 module.exports = {
-  'cli.usage': 'Usage: gsd-omp [install|uninstall|doctor|descriptor] [--root <path>] [--force] [--json]',
+  'cli.usage': 'Usage: gsd-omp [install|update|uninstall|doctor|descriptor] [--root <path>] [--force] [--json]',
 
   'cli.error.unknownCommand': 'Unknown command: {command}',
   'cli.error.unknownArgument': 'Unknown argument: {arg}',
@@ -12,6 +12,8 @@ module.exports = {
   'cli.error.cannotReadManifest': 'Cannot read {path}: {message}',
   'cli.error.unsupportedCore': 'gsd-omp requires @opengsd/gsd-core >=1.8.0; found {version}',
   'cli.error.refusingOverwrite': 'Refusing to overwrite unmanaged or modified file: {path} (rerun with --force to replace GSD-owned projections)',
+  'cli.error.updateCheckFailed': 'gsd-omp: could not check for updates (GitHub API unreachable or returned no release)',
+  'cli.error.updateFailed': 'gsd-omp: update failed — npm install did not exit cleanly; run the tarball URL manually and then `gsd-omp install`',
 
   'eos.error.unexpectedProfile': 'gsd-omp: EoS negotiation produced {profile}, expected programmatic-cli',
   'eos.error.unsupportedProtocol': 'gsd-omp: unsupported EoS protocol {version}',

--- a/src/locales/zh-CN.cjs
+++ b/src/locales/zh-CN.cjs
@@ -4,7 +4,7 @@
 // 键名与 en.cjs 一一对应；保持扁平点分命名空间。
 
 module.exports = {
-  'cli.usage': '用法：gsd-omp [install|uninstall|doctor|descriptor] [--root <路径>] [--force] [--json]',
+  'cli.usage': '用法：gsd-omp [install|update|uninstall|doctor|descriptor] [--root <路径>] [--force] [--json]',
 
   'cli.error.unknownCommand': '未知命令：{command}',
   'cli.error.unknownArgument': '未知参数：{arg}',
@@ -12,6 +12,8 @@ module.exports = {
   'cli.error.cannotReadManifest': '无法读取 {path}：{message}',
   'cli.error.unsupportedCore': 'gsd-omp 需要 @opengsd/gsd-core >=1.8.0；当前版本 {version}',
   'cli.error.refusingOverwrite': '拒绝覆盖未托管或已本地修改的文件：{path}（加 --force 可替换 GSD 托管的投影文件）',
+  'cli.error.updateCheckFailed': 'gsd-omp：无法检查更新（GitHub API 不可达或没有 release）',
+  'cli.error.updateFailed': 'gsd-omp：更新失败 —— npm install 未正常退出；请手动执行 tarball URL 安装后再运行 `gsd-omp install`',
 
   'eos.error.unexpectedProfile': 'gsd-omp：EoS 协商得到 {profile}，应为 programmatic-cli',
   'eos.error.unsupportedProtocol': 'gsd-omp：不支持的 EoS 协议版本 {version}',

--- a/test/installer.test.cjs
+++ b/test/installer.test.cjs
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { doctor, install, uninstall } = require('../bin/gsd-omp.cjs');
+const { doctor, install, uninstall, update } = require('../bin/gsd-omp.cjs');
 // Pin locale to English so the ownership-error regex stays deterministic
 // regardless of the dev shell's LANG.
 require('../src/locale.cjs').setLocale('en');
@@ -52,5 +52,19 @@ function temporaryRoot(name) {
     assert.equal(fs.existsSync(path.join(root, '.gsd-omp-manifest.json')), true);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+ test('update reports up-to-date when the local version matches the latest GitHub release', () => {
+  const packageJson = require('../package.json');
+  const bin = require('../bin/gsd-omp.cjs');
+  const original = bin.githubLatestRelease;
+  bin.githubLatestRelease = () => ({ tag_name: `v${packageJson.version}`, tarball_url: 'https://api.github.com/repos/tchivs/gsd-omp/tarball/x' });
+  try {
+    const result = update({ root: temporaryRoot('gsd-omp-update') });
+    assert.equal(result.upToDate, true);
+    assert.equal(result.current, packageJson.version);
+  } finally {
+    bin.githubLatestRelease = original;
   }
 });

--- a/test/locale.test.cjs
+++ b/test/locale.test.cjs
@@ -54,7 +54,7 @@ test('setLocale switches the active dictionary', () => {
     locale.t('cli.error.unknownArgument', { arg: '--banana' }),
     '未知参数：--banana',
   );
-  assert.equal(locale.t('cli.usage'), '用法：gsd-omp [install|uninstall|doctor|descriptor] [--root <路径>] [--force] [--json]');
+  assert.equal(locale.t('cli.usage'), '用法：gsd-omp [install|update|uninstall|doctor|descriptor] [--root <路径>] [--force] [--json]');
   locale.setLocale('en');
   assert.equal(locale.getLocale(), 'en');
 });


### PR DESCRIPTION
## Summary\n\nAdds `gsd-omp update` — a one-step upgrade:\n\n1. Query GitHub's latest release API (`releases/latest`)\n2. Compare against the installed `package.json` version\n3. Up-to-date → report and exit 0\n4. Newer → `npm install --global <tarball-url>` then re-run `install()` to re-project the managed extension, agents, and skills\n\nAlso updates usage string + locale keys (en/zh-CN), README upgrade docs, and adds a regression test with the GitHub API stubbed.\n\n## GSD core note\n\n`gsd-omp update` upgrades the bundled `@opengsd/gsd-core` (a dependency of this package). OMP's own engine tree at `~/.omp/agent/gsd-core/` is outside the plugin's management — the plugin resolves gsd-core from its own `node_modules`. Both READMEs document this.\n\n## Verification\n\n- `gsd-omp update` when already current → `{ upToDate: true, current: 1.0.3 }` (verified against the live GitHub API)\n- 23 tests passing\n- `node --check` clean