### PR TITLE
chore: release gsd-omp v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is third-party software. It is not endorsed, reviewed, or maintaine
 Install the released plugin globally, then project its managed extension, agents, and skills into OMP:
 
 ```bash
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.3.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.4.tar.gz
 gsd-omp install
 ```
 
@@ -149,7 +149,7 @@ If the update check fails (offline, GitHub unreachable), fall back to the manual
 
 ```bash
 gsd-omp uninstall
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.3.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.4.tar.gz
 gsd-omp install
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@
 全局安装已发布的插件，随后将其托管的扩展、agents 与 skills 投影到 OMP：
 
 ```bash
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.3.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.4.tar.gz
 gsd-omp install
 ```
 
@@ -150,7 +150,7 @@ gsd-omp update
 
 ```bash
 gsd-omp uninstall
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.3.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.4.tar.gz
 gsd-omp install
 ```
 

--- a/bin/gsd-omp.cjs
+++ b/bin/gsd-omp.cjs
@@ -51,8 +51,8 @@ function githubLatestRelease() {
   }
 }
 
-function update({ root: rootOverride, force = false } = {}) {
-  const release = githubLatestRelease();
+function update({ root: rootOverride, force = false, latestRelease } = {}) {
+  const release = (latestRelease || githubLatestRelease)();
   const latest = String(release.tag_name || '').replace(/^v/, '');
   if (latest && latest === packageJson.version) {
     return { upToDate: true, current: packageJson.version, root: runtimeRoot(rootOverride) };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-omp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-omp",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@opengsd/gsd-core": "^1.9.1"
@@ -462,7 +462,7 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
@@ -598,7 +598,7 @@
       }
     },
     "node_modules/dunder-proto": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
@@ -627,7 +627,7 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
@@ -657,7 +657,7 @@
       }
     },
     "node_modules/escape-html": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
@@ -877,7 +877,7 @@
       }
     },
     "node_modules/get-proto": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
@@ -1369,7 +1369,7 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
@@ -1385,7 +1385,7 @@
       }
     },
     "node_modules/side-channel-map": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
@@ -1403,7 +1403,7 @@
       }
     },
     "node_modules/side-channel-weakmap": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
@@ -1431,7 +1431,7 @@
       }
     },
     "node_modules/toidentifier": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
@@ -1510,7 +1510,7 @@
       }
     },
     "node_modules/wrappy": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-omp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Oh My Pi host plugin for the GSD Embeddable Orchestration System — extension bindings, slash-command surface, and Host-Integration SDK adapter for AI coding agents",
   "license": "MIT",
   "author": "tchivs",

--- a/test/installer.test.cjs
+++ b/test/installer.test.cjs
@@ -57,14 +57,12 @@ function temporaryRoot(name) {
 
  test('update reports up-to-date when the local version matches the latest GitHub release', () => {
   const packageJson = require('../package.json');
-  const bin = require('../bin/gsd-omp.cjs');
-  const original = bin.githubLatestRelease;
-  bin.githubLatestRelease = () => ({ tag_name: `v${packageJson.version}`, tarball_url: 'https://api.github.com/repos/tchivs/gsd-omp/tarball/x' });
-  try {
-    const result = update({ root: temporaryRoot('gsd-omp-update') });
-    assert.equal(result.upToDate, true);
-    assert.equal(result.current, packageJson.version);
-  } finally {
-    bin.githubLatestRelease = original;
-  }
+  const { update } = require('../bin/gsd-omp.cjs');
+  // Inject a stub instead of hitting the live GitHub API.
+  const result = update({
+    root: temporaryRoot('gsd-omp-update'),
+    latestRelease: () => ({ tag_name: `v${packageJson.version}`, tarball_url: 'https://api.github.com/repos/tchivs/gsd-omp/tarball/x' }),
+  });
+  assert.equal(result.upToDate, true);
+  assert.equal(result.current, packageJson.version);
 });


### PR DESCRIPTION
## Summary\n\n- bump `gsd-omp` to `1.0.4`\n- includes #15: `gsd-omp update` one-step upgrade command\n- test refactor: `update` accepts an injectable `latestRelease` so the regression test never hits the live GitHub API\n\n## Verification\n\n- `npm test` — 23 passing\n- `npm pack --dry-run`