### PR TITLE
fix: hide low-signal active-task widget banner

### DIFF
--- a/src/extension.cjs
+++ b/src/extension.cjs
@@ -1387,9 +1387,6 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     const checkpoint = !activeTaskCount && !recovery && !action ? resumableCheckpoint(cwd, state) : null;
     if (!state && !activeTaskCount && !action && !recovery && !checkpoint) return [];
     const recoveryCount = recovery?.failures.length || 0;
-    const activeRow = activeTaskCount
-      ? widgetColor(36, chinese ? `● ${activeTaskCount} 个原生任务运行中` : `● ${activeTaskCount} native task${activeTaskCount === 1 ? '' : 's'} running`)
-      : null;
     const recoveryRow = recoveryCount
       ? widgetColor(31, chinese ? `⛔ ${recoveryCount} 个原生任务待恢复` : `⛔ Native task recovery: ${recoveryCount} failed`)
       : null;
@@ -1397,25 +1394,22 @@ module.exports = function gsdPiExtension(pi, options = {}) {
       ? widgetColor(33, chinese ? `↻ 恢复阶段 ${checkpoint.phase}：${checkpoint.plansDone}/${checkpoint.plansTotal} 个计划已完成` : `↻ Resume Phase ${checkpoint.phase}: ${checkpoint.plansDone}/${checkpoint.plansTotal} plans complete`)
       : null;
     if (state?.unreadable) {
-      const rows = [activeRow, recoveryRow].filter(Boolean);
+      const rows = [recoveryRow].filter(Boolean);
       const lines = [widgetColor(31, chinese ? 'GSD · 状态文件无法解析' : 'GSD · state unreadable'), ...rows.map((row, index) => `${index === rows.length - 1 ? '└─' : '├─'} ${row}`)];
       if (recoveryRow) lines.push(`   ${widgetColor(2, recovery.command)}`);
       return lines;
     }
     const hasRisks = Boolean(state?.blockers || state?.concerns);
-    if (!hasRisks && !activeRow && !action && !recovery && !checkpoint) return [];
-    const heading = activeRow
-      ? widgetColor(36, chinese ? 'GSD · 任务运行中' : 'GSD · Tasks running')
-      : recovery
-        ? widgetColor(31, chinese ? 'GSD · 需要任务恢复' : 'GSD · Recovery needed')
-        : action
-          ? widgetColor(36, chinese ? 'GSD · 下一步' : 'GSD · Next Up')
-          : checkpoint
-            ? widgetColor(33, chinese ? 'GSD · 可恢复执行' : 'GSD · Resume available')
-            : widgetColor(33, chinese ? 'GSD · 需要关注' : 'GSD · Attention');
+    if (!hasRisks && !action && !recovery && !checkpoint) return [];
+    const heading = recovery
+      ? widgetColor(31, chinese ? 'GSD · 需要任务恢复' : 'GSD · Recovery needed')
+      : action
+        ? widgetColor(36, chinese ? 'GSD · 下一步' : 'GSD · Next Up')
+        : checkpoint
+          ? widgetColor(33, chinese ? 'GSD · 可恢复执行' : 'GSD · Resume available')
+          : widgetColor(33, chinese ? 'GSD · 需要关注' : 'GSD · Attention');
     const rows = [];
     if (hasRisks) rows.push(widgetRiskLine(state, chinese));
-    if (activeRow) rows.push(activeRow);
     if (recoveryRow) rows.push(recoveryRow);
     if (checkpointRow) rows.push(checkpointRow);
     if (action) rows.push(action.label.slice(0, 92));
@@ -3790,6 +3784,7 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
     extractNextAction,
     extractCheckpoint,
     extractTaskResults,
+    widgetLines,
     _nativeTaskActivityCount: nativeTaskActivityCount,
   };
 };

--- a/test/extension.test.cjs
+++ b/test/extension.test.cjs
@@ -216,6 +216,20 @@ test('failed GSD task request releases tracked names', async () => {
   }
 });
 
+
+test('does not render the low-signal active-task banner in the ordinary widget', async () => {
+  const root = gsdProjectRoot();
+  try {
+    const pi = mockPi();
+    extension(pi, { runtime: 'omp', runtimeRoot: root });
+    const ctx = { cwd: root };
+    await pi.events.get('tool_call')(taskSpawnCall('call_widget', ['Phase1Plan06Executor']), ctx);
+    const lines = extension._internals.widgetLines(root);
+    assert.equal(lines.some((line) => line.includes('个原生任务运行中') || line.includes('native task')), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 test('gsd-next does not advance while a native GSD task is still running', async () => {
   // /gsd-next must check native task activity BEFORE dispatching a saved
   // continuation, mirroring chooseNextAction. Otherwise it spawns the next


### PR DESCRIPTION
## Change\n\nRemove the persistent `● N 个原生任务运行中` row from the ordinary GSD widget.\n\n## Preserved safety\n\n- Native task activity tracking remains unchanged.\n- `/gsd-next` still blocks while tasks are active and emits the explicit task/Job-panel message.\n- `/gsd-status` continues to report active task counts.\n- Failed-task recovery rows remain visible.\n\n## Verification\n\n- `npm run lint`\n- 24 tests passing, including widget suppression regression and existing active-task guard test.