### PR TITLE
fix: make gsd-omp update safer

### DIFF
--- a/bin/gsd-omp.cjs
+++ b/bin/gsd-omp.cjs
@@ -54,23 +54,36 @@ function githubLatestRelease() {
 function update({ root: rootOverride, force = false, latestRelease } = {}) {
   const release = (latestRelease || githubLatestRelease)();
   const latest = String(release.tag_name || '').replace(/^v/, '');
-  if (latest && latest === packageJson.version) {
-    return { upToDate: true, current: packageJson.version, root: runtimeRoot(rootOverride) };
+  const comparison = compareVersions(latest, packageJson.version);
+  if (!latest || comparison <= 0) {
+    return { upToDate: comparison === 0, current: packageJson.version, latest: latest || null, root: runtimeRoot(rootOverride) };
   }
-  const tarball = release.tarball_url || `https://github.com/${GITHUB_REPO}/archive/refs/tags/${release.tag_name || 'main'}.tar.gz`;
-  const npmArgs = ['install', '--global', '--prefix', globalPrefix(), tarball];
-  if (!process.env.GSD_OMP_UPDATE_SKIP_BIN) npmArgs.push('--no-save');
+  const tarball = release.tarball_url || `https://github.com/${GITHUB_REPO}/archive/refs/tags/v${latest}.tar.gz`;
+  const npmArgs = ['install', '--global', tarball];
   const res = spawnSync('npm', npmArgs, { encoding: 'utf8', stdio: 'inherit', timeout: 300000 });
   if (res.status !== 0) throw new Error(t('cli.error.updateFailed'));
-  const installed = install({ root: rootOverride, force });
-  return {
-    updated: true,
-    from: packageJson.version,
-    to: latest || 'latest',
-    root: installed.root,
-    manifestPath: installed.manifestPath,
-    installed: installed.installed,
-  };
+
+  // The current process still contains the old package. Invoke the freshly
+  // installed CLI so projection uses the new extension, agents, skills, and
+  // bundled gsd-core rather than the old process's module graph.
+  const prefix = globalPrefix();
+  const cli = process.platform === 'win32'
+    ? path.join(prefix, 'gsd-omp.cmd')
+    : path.join(prefix, 'bin', 'gsd-omp');
+  const installArgs = ['install'];
+  if (rootOverride) installArgs.push('--root', rootOverride);
+  if (force) installArgs.push('--force');
+  const projection = spawnSync(cli, installArgs, { encoding: 'utf8', stdio: 'inherit', timeout: 120000 });
+  if (projection.status !== 0) throw new Error(t('cli.error.updateProjectionFailed'));
+  return { updated: true, from: packageJson.version, to: latest, root: runtimeRoot(rootOverride) };
+}
+
+function compareVersions(left, right) {
+  const parse = (value) => String(value || '').match(/^(\\d+)\\.(\\d+)\\.(\\d+)/)?.slice(1).map(Number) || null;
+  const a = parse(left);
+  const b = parse(right);
+  if (!a || !b) return 0;
+  return a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
 }
 
 function globalPrefix() {

--- a/src/locales/en.cjs
+++ b/src/locales/en.cjs
@@ -14,6 +14,7 @@ module.exports = {
   'cli.error.refusingOverwrite': 'Refusing to overwrite unmanaged or modified file: {path} (rerun with --force to replace GSD-owned projections)',
   'cli.error.updateCheckFailed': 'gsd-omp: could not check for updates (GitHub API unreachable or returned no release)',
   'cli.error.updateFailed': 'gsd-omp: update failed — npm install did not exit cleanly; run the tarball URL manually and then `gsd-omp install`',
+  'cli.error.updateProjectionFailed': 'gsd-omp: update installed the new package but could not re-project OMP files; run `gsd-omp install` manually',
 
   'eos.error.unexpectedProfile': 'gsd-omp: EoS negotiation produced {profile}, expected programmatic-cli',
   'eos.error.unsupportedProtocol': 'gsd-omp: unsupported EoS protocol {version}',

--- a/src/locales/zh-CN.cjs
+++ b/src/locales/zh-CN.cjs
@@ -14,6 +14,7 @@ module.exports = {
   'cli.error.refusingOverwrite': '拒绝覆盖未托管或已本地修改的文件：{path}（加 --force 可替换 GSD 托管的投影文件）',
   'cli.error.updateCheckFailed': 'gsd-omp：无法检查更新（GitHub API 不可达或没有 release）',
   'cli.error.updateFailed': 'gsd-omp：更新失败 —— npm install 未正常退出；请手动执行 tarball URL 安装后再运行 `gsd-omp install`',
+  'cli.error.updateProjectionFailed': 'gsd-omp：更新已安装新包，但无法重新投影 OMP 文件；请手动运行 `gsd-omp install`',
 
   'eos.error.unexpectedProfile': 'gsd-omp：EoS 协商得到 {profile}，应为 programmatic-cli',
   'eos.error.unsupportedProtocol': 'gsd-omp：不支持的 EoS 协议版本 {version}',


### PR DESCRIPTION
Hardens the existing gsd-omp update command: compares semantic versions and skips downgrades, installs the tarball without forcing a global prefix, re-runs the freshly installed CLI for projection, forwards --root/--force, and reports projection failure explicitly. Lint and 24 tests pass.