### PR TITLE
fix: gsd_invoke zod schema breaks extension load on OMP >= 17.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ gsd-omp install
 
 `PI_CODING_AGENT_DIR` is honored. Without it, files are installed under `~/.omp/agent`.
 
+### Agents directory
+
+The in-session extension exports `GSD_AGENTS_DIR` (defaulting to `<runtimeRoot>/agents`, i.e. `~/.omp/agent/agents`) and passes it to every `gsd-tools` invocation together with `GSD_RUNTIME=omp`.
+
+This is the sanctioned mechanism, not a shim: `GSD_AGENTS_DIR` is the highest-priority override in gsd-core's `getAgentsDir` contract — it is consulted before any runtime lookup, for any runtime. OMP's config root is not a registered gsd-core runtime (the registry ships `pi`, not `omp`), so without this variable the `init.progress` / `init.new-project` agent check would fall back to `~/.claude/agents` and report every GSD agent as missing.
+
+The variable is only set when the environment does not already define it. If you manage the agents projection yourself, set `GSD_AGENTS_DIR` before starting OMP and the plugin uses your location as-is. (`PI_CODING_AGENT_DIR` controls where the installer writes files; `GSD_AGENTS_DIR` controls where gsd-core looks for them.)
+
 Restart OMP after installation, then use:
 
 ```text

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,14 @@ gsd-omp install
 
 支持 `PI_CODING_AGENT_DIR` 环境变量。未设置时，文件安装到 `~/.omp/agent`。
 
+### agents 目录
+
+会话内扩展会导出 `GSD_AGENTS_DIR`（默认指向 `<runtimeRoot>/agents`，即 `~/.omp/agent/agents`），并在每次调用 `gsd-tools` 时连同 `GSD_RUNTIME=omp` 一起传入。
+
+这是受支持的正规机制，不是 workaround：`GSD_AGENTS_DIR` 是 gsd-core `getAgentsDir` 契约中优先级最高的覆盖项——在任何运行时查找之前被优先检查，适用于所有运行时。OMP 的配置根目录不是 gsd-core 已注册的运行时（注册表中只有 `pi`，没有 `omp`），因此没有该变量时，`init.progress` / `init.new-project` 的 agents 检查会回退到 `~/.claude/agents`，并把所有 GSD agents 报告为缺失。
+
+仅当环境中尚未定义该变量时插件才会写入它。如果你自行管理 agents 投影，可在启动 OMP 前设置 `GSD_AGENTS_DIR`，插件会原样使用你的路径。（`PI_CODING_AGENT_DIR` 控制安装器把文件写到哪里；`GSD_AGENTS_DIR` 控制 gsd-core 到哪里查找 agents。）
+
 安装完成后重启 OMP，即可使用：
 
 ```text

--- a/src/extension.cjs
+++ b/src/extension.cjs
@@ -3667,7 +3667,7 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
     parameters: z.object({
       family: z.string().default('query'),
       subcommand: z.string().default('help'),
-      args: z.array(z.string()).default([]),
+      args: z.array(z.string()).default(() => []),
       raw: z.boolean().optional(),
     }),
     async execute(_toolCallId, params, signal, onUpdate, ctx) {


### PR DESCRIPTION
## Problem

Since OMP 17.2.8 (2026-08-04), the projected extension fails to load:

```
Failed to load extension: .../extensions/gsd-omp.ts: ParseError: A mutable default value must be specified as a factory
```

Every /gsd-* command and the gsd_invoke tool disappear on OMP latest (17.2.9). CI's "OMP latest host smoke" job has been red since.

## Root cause

OMP 17.2.8 upgraded its bundled omptype schema engine, which now rejects mutable static defaults in zod schemas. The gsd_invoke tool's parameters used `z.array(z.string()).default([])` — an array literal as a static default.

## Fix

`default(() => [])` — the factory form. Behavior-identical (the factory is invoked per access, same as zod semantics), accepted by both old and new omptype engines.

## Verification

host-smoke passes on OMP 17.0.3, 17.1.8, and 17.2.9 (74 extension commands + xd://gsd_invoke). Lint + 24/24 unit tests pass.