### PR TITLE
chore: release gsd-omp v1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is third-party software. It is not endorsed, reviewed, or maintaine
 Install the released plugin globally, then project its managed extension, agents, and skills into OMP:
 
 ```bash
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.5.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.6.tar.gz
 gsd-omp install
 ```
 
@@ -157,7 +157,7 @@ If the update check fails (offline, GitHub unreachable), fall back to the manual
 
 ```bash
 gsd-omp uninstall
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.5.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.6.tar.gz
 gsd-omp install
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@
 全局安装已发布的插件，随后将其托管的扩展、agents 与 skills 投影到 OMP：
 
 ```bash
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.5.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.6.tar.gz
 gsd-omp install
 ```
 
@@ -158,7 +158,7 @@ gsd-omp update
 
 ```bash
 gsd-omp uninstall
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.5.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.6.tar.gz
 gsd-omp install
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-omp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-omp",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@opengsd/gsd-core": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-omp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Oh My Pi host plugin for the GSD Embeddable Orchestration System — extension bindings, slash-command surface, and Host-Integration SDK adapter for AI coding agents",
   "license": "MIT",
   "author": "tchivs",


### PR DESCRIPTION
## What

Bump to v1.0.6. Contains since v1.0.5:

- **fix: gsd_invoke zod schema breaks extension load on OMP >= 17.2.8 (#22)** — OMP 17.2.8 upgraded its bundled omptype schema engine; mutable static zod defaults are now rejected, so the projected extension failed to load and all /gsd-* commands + gsd_invoke vanished on OMP latest. Fixed with the factory form `default(() => [])`. host-smoke passes on 17.0.3 / 17.1.8 / 17.2.9.
- **docs: GSD_AGENTS_DIR as the sanctioned agents-dir override (#21)**
- **fix: pump fast-uri to 3.1.4 (vul) (#9)**

## Why now

`@oh-my-pi/pi-coding-agent@latest` is 17.2.9; without #22 the extension is broken for every user on OMP >= 17.2.8, and gsd-omp update installs from `releases/latest`.

Verification: lint + 24/24 tests (release-metadata test asserts lock/README match v1.0.6).