### PR TITLE
feat: automate upstream monitoring and releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Runtime dependency on the upstream GSD core. A bump PR triggers the full
+  # CI (unit + host smoke on pinned and latest OMP), which is the adaptation
+  # gate for gsd-core changes.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
   schedule:
-    - cron: '17 5 * * 1'
+    - cron: '17 5 * * *'
   workflow_dispatch:
 
 permissions:
@@ -65,3 +65,39 @@ jobs:
           GSD_OMP_BIN: gsd-omp
           OMP_VERSION: ${{ matrix.omp-version }}
         run: node scripts/host-smoke.cjs
+
+  upstream-report:
+    name: Report upstream drift
+    needs: [unit, host-smoke]
+    if: github.event_name == 'schedule' && failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          omp_latest="$(npm view @oh-my-pi/pi-coding-agent version 2>/dev/null || echo unknown)"
+          gsd_core_latest="$(npm view @opengsd/gsd-core version 2>/dev/null || echo unknown)"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          title="Upstream drift: scheduled CI failed (OMP ${omp_latest}, gsd-core ${gsd_core_latest})"
+          existing="$(gh issue list --repo "${{ github.repository }}" --search 'in:title "Upstream drift"' --state open --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --repo "${{ github.repository }}" \
+              --body "Re-failed on $(date -u +%Y-%m-%dT%H:%MZ) · OMP ${omp_latest} · gsd-core ${gsd_core_latest} · ${run_url}"
+            echo "updated issue #${existing}"
+          else
+            gh issue create --repo "${{ github.repository }}" --title "${title}" --body "The scheduled CI run ${run_url} failed against the latest upstreams:
+
+          - @oh-my-pi/pi-coding-agent: **${omp_latest}**
+          - @opengsd/gsd-core: **${gsd_core_latest}**
+
+          Check the failing \`OMP latest host smoke\` job logs. Likely causes:
+
+          - OMP changed its extension/omptype contract (compare the assertions in \`scripts/host-smoke.cjs\`); prior instance: omptype 17.2.8 rejecting mutable static zod defaults (fixed in #22).
+          - gsd-core API drift in the extension bootstrap (\`src/extension.cjs\`).
+
+          To resolve: adapt in a PR, verify host-smoke passes on both the pinned and the latest OMP, then close this issue."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,176 @@
+name: Auto-release
+
+# Publishes a new version whenever main moves ahead of the latest release:
+# bumps the patch version, opens/updates a release PR, waits for CI, merges,
+# tags, and creates the GitHub release (the source for `gsd-omp update`).
+#
+# main is protected by the "Protect main" ruleset (pull_request +
+# required_status_checks), so the bump itself goes through a PR.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '22.x'
+
+      - name: Resolve release state
+        id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          latest_tag="$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name 2>/dev/null || echo '')"
+          head_tag="$(git describe --exact-match --tags HEAD 2>/dev/null || echo '')"
+          echo "version=${version} latest_tag=${latest_tag} head_tag=${head_tag}"
+          if [ -n "${head_tag}" ] && [ "${head_tag}" = "v${version}" ]; then
+            # HEAD is exactly the published version: nothing to do.
+            echo "action=none" >> "$GITHUB_OUTPUT"
+          elif [ -n "${latest_tag}" ] && [ "${latest_tag}" != "v${version}" ]; then
+            # Version already bumped past the latest tag (e.g. a release PR
+            # was just merged but tagging failed). Tag the current HEAD.
+            echo "action=tag" >> "$GITHUB_OUTPUT"
+            echo "new_version=${version}" >> "$GITHUB_OUTPUT"
+          else
+            new_version="$(node -e "const s='${version}'.split('.'); console.log(s[0]+'.'+s[1]+'.'+(+s[2]+1))")"
+            echo "action=bump" >> "$GITHUB_OUTPUT"
+            echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update release PR
+        id: pr
+        if: steps.state.outputs.action == 'bump'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          new_version="${{ steps.state.outputs.new_version }}"
+          branch="chore/release-v${new_version}"
+          git config user.name "gsd-omp release bot"
+          git config user.email "actions@users.noreply.github.com"
+          existing="$(gh pr list --repo "${{ github.repository }}" --search 'chore: release gsd-omp' --state open --json number,headRefName --jq '.[0] // empty')"
+          if [ -n "${existing}" ]; then
+            pr_num="$(printf '%s' "${existing}" | jq -r .number)"
+            head_ref="$(printf '%s' "${existing}" | jq -r .headRefName)"
+            git fetch origin "${head_ref}"
+            git checkout -B "${head_ref}" FETCH_HEAD
+            git rebase origin/main
+            node scripts/bump-version.cjs "${new_version}"
+            git add -A
+            git -c user.name="gsd-omp release bot" -c user.email="actions@users.noreply.github.com" commit -m "chore: release gsd-omp v${new_version}" || echo "no new changes"
+            git push --force origin "${head_ref}"
+            echo "number=${pr_num}" >> "$GITHUB_OUTPUT"
+          else
+            git checkout -b "${branch}"
+            node scripts/bump-version.cjs "${new_version}"
+            git add -A
+            git -c user.name="gsd-omp release bot" -c user.email="actions@users.noreply.github.com" commit -m "chore: release gsd-omp v${new_version}"
+            git push -u origin "${branch}"
+            pr_num="$(gh pr create --repo "${{ github.repository }}" --base main --head "${branch}" \
+              --title "chore: release gsd-omp v${new_version}" \
+              --body "Automated release PR created by the Auto-release workflow (bumps package version and README install URLs)." \
+              --json number --jq .number)"
+            echo "number=${pr_num}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for CI and merge release PR
+        if: steps.state.outputs.action == 'bump'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pr_num="${{ steps.pr.outputs.number }}"
+          new_version="${{ steps.state.outputs.new_version }}"
+          for _ in $(seq 1 80); do
+            state="$(gh pr view "${pr_num}" --repo "${{ github.repository }}" --json state,mergeStateStatus --jq '"\(.state)|\(.mergeStateStatus)"')"
+            pr_state="${state%%|*}"
+            mss="${state##*|}"
+            if [ "${pr_state}" = "MERGED" ]; then
+              echo "merged"
+              break
+            fi
+            if [ "${pr_state}" != "OPEN" ]; then
+              echo "PR ${pr_num} is ${pr_state}; manual intervention needed"
+              exit 0
+            fi
+            case "${mss}" in
+              CLEAN|UNSTABLE)
+                gh pr merge "${pr_num}" --repo "${{ github.repository }}" --squash
+                break
+                ;;
+              BLOCKED)
+                sleep 15
+                ;;
+              BEHIND|DIRTY)
+                head_ref="$(gh pr view "${pr_num}" --repo "${{ github.repository }}" --json headRefName --jq .headRefName)"
+                git fetch origin main "${head_ref}"
+                git checkout -B "${head_ref}" FETCH_HEAD
+                git rebase origin/main
+                node scripts/bump-version.cjs "${new_version}"
+                git add -A
+                git -c user.name="gsd-omp release bot" -c user.email="actions@users.noreply.github.com" commit -m "chore: release gsd-omp v${new_version}" || echo "no new changes"
+                git push --force origin "${head_ref}"
+                sleep 15
+                ;;
+              *)
+                echo "unexpected merge state ${mss}; sleeping"
+                sleep 15
+                ;;
+            esac
+          done
+
+      - name: Tag and publish release
+        if: steps.state.outputs.action != 'none'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          new_version="${{ steps.state.outputs.new_version }}"
+          if [ "${{ steps.state.outputs.action }}" = "bump" ]; then
+            pr_state="$(gh pr view "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --json state --jq .state)"
+            if [ "${pr_state}" != "MERGED" ]; then
+              echo "release PR not merged yet (${pr_state}); skipping tag, next push will continue"
+              exit 0
+            fi
+            sha="$(gh pr view "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --json mergeCommit --jq .mergeCommit.oid)"
+            # Merge commits can lag behind the API briefly; retry.
+            for _ in $(seq 1 10); do
+              [ -n "${sha}" ] && [ "${sha}" != "null" ] && break
+              sleep 3
+              sha="$(gh pr view "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --json mergeCommit --jq .mergeCommit.oid)"
+            done
+          else
+            sha="$(git rev-parse HEAD)"
+          fi
+          tag="v${new_version}"
+          if ! gh api "repos/${{ github.repository }}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+            gh api --method POST "repos/${{ github.repository }}/git/refs" \
+              -f "ref=refs/tags/${tag}" -f "sha=${sha}"
+          fi
+          if ! gh release view "${tag}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            prev="$(gh release list --repo "${{ github.repository }}" --limit 2 --json tagName --jq 'if length > 1 then .[1].tagName else .[0].tagName end')"
+            notes="$(gh api "repos/${{ github.repository }}/compare/${prev}...${sha}" --jq '.commits[].commit.message | split("\n")[0]' | sed 's/^/- /')"
+            gh release create "${tag}" --repo "${{ github.repository }}" --title "gsd-omp v${new_version}" --notes "${notes}"
+          fi
+          echo "published ${tag} at ${sha}"

--- a/scripts/bump-version.cjs
+++ b/scripts/bump-version.cjs
@@ -1,0 +1,51 @@
+'use strict';
+
+// Bump gsd-omp's version across package.json, package-lock.json, and both
+// README install URLs. Idempotent: running with the current version is a no-op.
+//
+// Usage: node scripts/bump-version.cjs <semver>
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const version = process.argv[2];
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error(`usage: node scripts/bump-version.cjs <semver> (got: ${version})`);
+  process.exit(1);
+}
+
+const pkgPath = path.join(root, 'package.json');
+const lockPath = path.join(root, 'package-lock.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+
+if (pkg.version === version) {
+  console.log(`already at ${version}`);
+  process.exit(0);
+}
+
+const readmes = ['README.md', 'README.zh-CN.md'];
+for (const readme of readmes) {
+  const p = path.join(root, readme);
+  if (!/v\d+\.\d+\.\d+\.tar\.gz/.test(fs.readFileSync(p, 'utf8'))) {
+    console.error(`no versioned install URL found in ${readme}`);
+    process.exit(1);
+  }
+}
+
+pkg.version = version;
+lock.version = version;
+if (lock.packages && lock.packages['']) lock.packages[''].version = version;
+
+fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+
+for (const readme of readmes) {
+  const p = path.join(root, readme);
+  const text = fs.readFileSync(p, 'utf8');
+  fs.writeFileSync(p, text.replace(/v\d+\.\d+\.\d+\.tar\.gz/g, `v${version}.tar.gz`));
+}
+
+console.log(`bumped to ${version}`);


### PR DESCRIPTION
## What

Three pieces of automation, all responding to the OMP 17.2.8 incident (upstream broke the extension silently; nobody noticed for a day):

**1. Auto-release** (`.github/workflows/release.yml`)
- Triggered by every push to main. If HEAD is already published, exits.
- Otherwise bumps the patch version via a release PR (main's ruleset requires PRs), waits for CI, squash-merges, then tags and creates the GitHub release that `gsd-omp update` consumes.
- Race-safe: if a release PR merge lands before tagging (workflow concurrency), the next run tags the current HEAD instead of bumping again.

**2. Upstream drift reporting** (ci.yml)
- Scheduled CI moves from weekly to **daily**; the matrix already covers OMP 17.0.3 + latest.
- On scheduled failure, opens (or updates) an issue with the failing upstream versions (OMP + gsd-core) and diagnosis pointers, so a regression like omptype 17.2.8 never goes unnoticed again.

**3. Dependabot** (`.github/dependabot.yml`)
- Daily npm updates: `@opengsd/gsd-core` bump PRs are gated by the full CI matrix (host smoke on pinned + latest OMP) — that is the automated adaptation gate for gsd-core changes.
- Weekly GitHub Actions updates.

Plus `scripts/bump-version.cjs` (idempotent bump across package.json, lockfile, and both README install URLs; the existing release-metadata test asserts consistency).

## Verification
- All three YAML files parse; workflows validated locally.
- bump-version.cjs round-trips 1.0.6 → 1.0.7 → 1.0.6 with clean tree; 24/24 unit tests pass.
- State-resolution logic (none / tag / bump) exercised against current HEAD (= v1.0.6 tag → no-op).