### PR TITLE
Upgrade @opengsd/gsd-core from 1.10.0 to 1.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ concurrency:
 
 jobs:
   unit:
-    name: Node 22 unit tests
+    name: Node 24 unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Node.js 22
+      - name: Set up Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -44,10 +44,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Node.js 22
+      - name: Set up Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: npm
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GSD for Oh My Pi
+[![CI](https://img.shields.io/github/actions/workflow/status/tchivs/gsd-omp/ci.yml?branch=main&logo=githubactions&logoColor=white&label=CI)](https://github.com/tchivs/gsd-omp/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/tchivs/gsd-omp?logo=github&label=release)](https://github.com/tchivs/gsd-omp/releases)
 [![License: MIT](https://img.shields.io/github/license/tchivs/gsd-omp?color=blue)](./LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%E2%89%A522-339933?logo=node.js&logoColor=white)](https://nodejs.org)
@@ -6,6 +7,8 @@
 [![OMP EoS](https://img.shields.io/badge/OMP-EoS%20v1-6c31c4)](#eos-contract)
 [![Last Commit](https://img.shields.io/github/last-commit/tchivs/gsd-omp?logo=git&logoColor=white)](https://github.com/tchivs/gsd-omp/commits)
 [![Stars](https://img.shields.io/github/stars/tchivs/gsd-omp?style=social)](https://github.com/tchivs/gsd-omp/stargazers)
+[![Contributors](https://img.shields.io/github/contributors/tchivs/gsd-omp?color=orange&logo=github)](https://github.com/tchivs/gsd-omp/graphs/contributors)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/tchivs/gsd-omp/pulls)
 
 **English** · [简体中文](./README.zh-CN.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,12 +1,15 @@
 # GSD for Oh My Pi
 
+[![CI](https://img.shields.io/github/actions/workflow/status/tchivs/gsd-omp/ci.yml?branch=main&logo=githubactions&logoColor=white&label=CI)](https://github.com/tchivs/gsd-omp/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/tchivs/gsd-omp?logo=github&label=release)](https://github.com/tchivs/gsd-omp/releases)
 [![License: MIT](https://img.shields.io/github/license/tchivs/gsd-omp?color=blue)](./LICENSE)
 [![Node.js](https://img.shields.io/badge/node-%E2%89%A522-339933?logo=node.js&logoColor=white)](https://nodejs.org)
-[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%89%A51.8.0-0066cc)](https://github.com/open-gsd/gsd-core)
+[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%88%991.8.0-0066cc)](https://github.com/open-gsd/gsd-core)
 [![OMP EoS](https://img.shields.io/badge/OMP-EoS%20v1-6c31c4)](#eos-契约)
 [![Last Commit](https://img.shields.io/github/last-commit/tchivs/gsd-omp?logo=git&logoColor=white)](https://github.com/tchivs/gsd-omp/commits)
 [![Stars](https://img.shields.io/github/stars/tchivs/gsd-omp?style=social)](https://github.com/tchivs/gsd-omp/stargazers)
+[![Contributors](https://img.shields.io/github/contributors/tchivs/gsd-omp?color=orange&logo=github)](https://github.com/tchivs/gsd-omp/graphs/contributors)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](https://github.com/tchivs/gsd-omp/pulls)
 
 [English](./README.md) · **简体中文**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
-        "@opengsd/gsd-core": "^1.10.0"
+        "@opengsd/gsd-core": "^1.11.0"
       },
       "bin": {
         "gsd-omp": "bin/gsd-omp.cjs"
       },
       "engines": {
-        "gsd": ">=1.10.0",
-        "node": ">=22.0.0"
+        "gsd": ">=1.11.0",
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@opengsd/gsd-core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@opengsd/gsd-core/-/gsd-core-1.10.0.tgz",
-      "integrity": "sha512-sddfW47TR9MJf2n6Dpf9RSf4l5yGUXL3JT1BlYRzmr/K5Z9Ka+O2hxBDCvKv+LRGYhTtu4zdeKhb1shCi87Mxg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@opengsd/gsd-core/-/gsd-core-1.11.0.tgz",
+      "integrity": "sha512-z1RLWsQshYViJIk94SB0x9/AYPykj5LIuLxwjS0s+WgaCBgVtTknCsVR3x4itrBeqmiUEvGiN6cO/bOay0zOiQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",
@@ -362,7 +362,7 @@
         "gsd-tools": "gsd-core/bin/gsd-tools.cjs"
       },
       "engines": {
-        "node": ">=22.0.0",
+        "node": ">=24.0.0",
         "npm": ">=10.0.0"
       },
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "prepack": "npm run lint && npm test"
   },
   "dependencies": {
-    "@opengsd/gsd-core": "^1.10.0"
+    "@opengsd/gsd-core": "^1.11.0"
   },
   "engines": {
-    "node": ">=22.0.0",
-    "gsd": ">=1.10.0"
+    "node": ">=24.0.0",
+    "gsd": ">=1.11.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bump `@opengsd/gsd-core` from `^1.10.0` to `^1.11.0` and update Node engine floor from 22 to 24 (required by gsd-core 1.11.0).

## Changes

- `@opengsd/gsd-core`: `^1.10.0` → `^1.11.0`
- `engines.node`: `>=22.0.0` → `>=24.0.0`
- `engines.gsd`: `>=1.10.0` → `>=1.11.0`
- CI workflow: Node `22.x` → `24.x` (unit + host-smoke jobs)

## Why

gsd-core 1.11.0 fixes the frontmatter round-trip bug (#3497) that caused `STATE.md` to lose its closing `---` separator on state writes — the root cause of the **'GSD state file could not be parsed'** error reported in downstream projects.

### Key gsd-core 1.11.0 fixes relevant to gsd-omp

- **#3497**: Frontmatter round-trips no longer double backslashes / lose closing `---`
- **#3471**: `state json` and state-mutating commands now agree with disk
- **#2573**: STATE.md records `state_head` commit stamp
- **#3416**: Node 24 required (Active LTS line)
- **#3199**: `scanPhasePlans` is now the sole plan-count source

## Verification

- ✅ `npm install` — gsd-core 1.11.0 installed, `npm ls` clean
- ✅ `npm run lint` — all syntax checks pass
- ✅ `npm test` — 24/24 tests pass
- ⚠️ `host-smoke` — fails locally (OMP 18.0.5 RPC mode env issue); **same failure on 1.10.0**, not a regression. CI on clean env with global install passes.

## Merge behavior

Merging this PR to `main` will trigger the **Auto-release** workflow, which automatically bumps to `v1.0.14`, creates a release PR, waits for CI, merges, and tags the GitHub release.