### PR TITLE
docs: update README badges and requirements to Node 24 / gsd-core 1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/tchivs/gsd-omp/ci.yml?branch=main&logo=githubactions&logoColor=white&label=CI)](https://github.com/tchivs/gsd-omp/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/tchivs/gsd-omp?logo=github&label=release)](https://github.com/tchivs/gsd-omp/releases)
 [![License: MIT](https://img.shields.io/github/license/tchivs/gsd-omp?color=blue)](./LICENSE)
-[![Node.js](https://img.shields.io/badge/node-%E2%89%A522-339933?logo=node.js&logoColor=white)](https://nodejs.org)
-[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%89%A51.8.0-0066cc)](https://github.com/open-gsd/gsd-core)
+[![Node.js](https://img.shields.io/badge/node-%E2%89%A524-339933?logo=node.js&logoColor=white)](https://nodejs.org)
+[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%89%A51.11.0-0066cc)](https://github.com/open-gsd/gsd-core)
 [![OMP EoS](https://img.shields.io/badge/OMP-EoS%20v1-6c31c4)](#eos-contract)
 [![Last Commit](https://img.shields.io/github/last-commit/tchivs/gsd-omp?logo=git&logoColor=white)](https://github.com/tchivs/gsd-omp/commits)
 [![Stars](https://img.shields.io/github/stars/tchivs/gsd-omp?style=social)](https://github.com/tchivs/gsd-omp/stargazers)
@@ -18,9 +18,9 @@ This project is third-party software. It is not endorsed, reviewed, or maintaine
 
 ## Requirements
 
-- Node.js 22 or newer
+- Node.js 24 or newer
 - Oh My Pi with native ExtensionAPI support
-- GSD Core 1.8.0 or newer; installed automatically as this package's dependency
+- GSD Core 1.11.0 or newer; installed automatically as this package's dependency
 
 ## Install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,8 +3,8 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/tchivs/gsd-omp/ci.yml?branch=main&logo=githubactions&logoColor=white&label=CI)](https://github.com/tchivs/gsd-omp/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/tchivs/gsd-omp?logo=github&label=release)](https://github.com/tchivs/gsd-omp/releases)
 [![License: MIT](https://img.shields.io/github/license/tchivs/gsd-omp?color=blue)](./LICENSE)
-[![Node.js](https://img.shields.io/badge/node-%E2%89%A522-339933?logo=node.js&logoColor=white)](https://nodejs.org)
-[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%88%991.8.0-0066cc)](https://github.com/open-gsd/gsd-core)
+[![Node.js](https://img.shields.io/badge/node-%E2%89%A524-339933?logo=node.js&logoColor=white)](https://nodejs.org)
+[![GSD Core](https://img.shields.io/badge/gsd--core-%E2%89%A51.11.0-0066cc)](https://github.com/open-gsd/gsd-core)
 [![OMP EoS](https://img.shields.io/badge/OMP-EoS%20v1-6c31c4)](#eos-契约)
 [![Last Commit](https://img.shields.io/github/last-commit/tchivs/gsd-omp?logo=git&logoColor=white)](https://github.com/tchivs/gsd-omp/commits)
 [![Stars](https://img.shields.io/github/stars/tchivs/gsd-omp?style=social)](https://github.com/tchivs/gsd-omp/stargazers)
@@ -19,9 +19,9 @@
 
 ## 环境要求
 
-- Node.js 22 或更高版本
+- Node.js 24 或更高版本
 - 启用原生 ExtensionAPI 的 Oh My Pi
-- GSD Core 1.8.0 或更高版本；作为本包依赖自动安装
+- GSD Core 1.11.0 或更高版本；作为本包依赖自动安装
 
 ## 安装
 


### PR DESCRIPTION
## Summary

The gsd-core 1.11.0 upgrade (#43) bumped `engines.node` to `>=24.0.0` and `engines.gsd` to `>=1.11.0`, but the README badges and Requirements sections still claimed Node 22 and gsd-core 1.8.0.

## Changes

**README.md:**
- Node.js badge: `≥22` → `≥24`
- GSD Core badge: `≥1.8.0` → `≥1.11.0`
- Requirements: `Node.js 22 or newer` → `Node.js 24 or newer`
- Requirements: `GSD Core 1.8.0 or newer` → `GSD Core 1.11.0 or newer`

**README.zh-CN.md:**
- Same badge and requirement updates in Chinese

## Why

Node 22 users following the README would install successfully (npm engine warnings are non-fatal) but then fail at runtime when gsd-core 1.11.0 uses Node 24 APIs (e.g. `RegExp.escape`).