### PR TITLE
fix: improve OMP native progress and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The plugin also registers the `gsd_invoke` tool for structured access to the pub
 
 ## Commands
 
-The plugin registers 39 slash commands and the `gsd_invoke` tool. Commands are grouped by project lifecycle; descriptions are taken verbatim from the registered command metadata.
+The plugin registers 40 slash commands and the `gsd_invoke` tool. Commands are grouped by project lifecycle; descriptions are taken verbatim from the registered command metadata.
+
 
 ### Entry & status
 
@@ -63,6 +64,7 @@ The plugin registers 39 slash commands and the `gsd_invoke` tool. Commands are g
 | `/gsd-next` | Show or prepare the next localized GSD action |
 | `/gsd-progress` | Show GSD progress or advance through its gated next-step workflow |
 | `/gsd-status` | Show a localized GSD project summary |
+| `/omp-native` | Show OMP-native task execution status and entry points |
 | `/gsd <family> <subcommand> [args]` | Invoke the public `gsd-tools` CLI directly |
 
 ### Project lifecycle

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,7 +55,8 @@ gsd-omp install
 
 ## 命令
 
-插件注册了 39 个斜杠命令与 `gsd_invoke` 工具。下表按项目生命周期分组,描述取自命令注册元数据。
+插件注册了 40 个斜杠命令与 `gsd_invoke` 工具。下表按项目生命周期分组,描述取自命令注册元数据。
+
 
 ### 入口与状态
 
@@ -64,6 +65,7 @@ gsd-omp install
 | `/gsd-next` | 显示或准备下一个本地化的 GSD 动作 |
 | `/gsd-progress` | 显示 GSD 进度,或在门控的下一步工作流中推进 |
 | `/gsd-status` | 显示本地化的 GSD 项目摘要 |
+| `/omp-native` | 显示 OMP 原生任务执行状态与入口 |
 | `/gsd <family> <subcommand> [args]` | 直接调用公共 `gsd-tools` CLI |
 
 ### 项目生命周期

--- a/bin/gsd-omp.cjs
+++ b/bin/gsd-omp.cjs
@@ -12,6 +12,11 @@ const packageJson = require('../package.json');
 const { t } = require('../src/locale.cjs');
 
 const MANIFEST_NAME = '.gsd-omp-manifest.json';
+const LEGACY_EXTENSION_PATHS = Object.freeze([
+  path.join('extensions', 'gsd-omp.cjs'),
+  path.join('extensions', 'gsd-omp.cjs.bak-mutable-default'),
+]);
+const LEGACY_EXTENSION_MARKER = 'GSD extension for Pi-compatible hosts';
 const GITHUB_REPO = 'tchivs/gsd-omp';
 const RELEASE_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
 const RELEASE_PAGE = `https://github.com/${GITHUB_REPO}/releases/latest`;
@@ -62,6 +67,27 @@ function safeTarget(root, filePath, errorFactory) {
 
 function safeArtifactTarget(root, filePath) {
   return safeTarget(root, filePath, (target) => new Error(t('cli.error.refusingOverwrite', { path: target })));
+}
+function legacyArtifactFiles(root) {
+  return LEGACY_EXTENSION_PATHS.flatMap((relativePath) => {
+    const target = safeArtifactTarget(root, relativePath);
+    let stat;
+    try {
+      stat = fs.lstatSync(target);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return [];
+      throw error;
+    }
+    if (!stat.isFile() || stat.isSymbolicLink()) return [];
+    let content;
+    try {
+      content = fs.readFileSync(target, 'utf8');
+    } catch {
+      return [];
+    }
+    if (!content.includes(LEGACY_EXTENSION_MARKER)) return [];
+    return [{ path: relativePath, sha256: sha256(content) }];
+  });
 }
 
 function validateManifest(root, manifest) {
@@ -197,7 +223,7 @@ function update({ root: rootOverride, force = false, latestRelease, json = false
 }
 
 function compareVersions(left, right) {
-  const parse = (value) => String(value || '').match(/^(\\d+)\\.(\\d+)\\.(\\d+)/)?.slice(1).map(Number) || null;
+  const parse = (value) => String(value || '').match(/^(\d+)\.(\d+)\.(\d+)/)?.slice(1).map(Number) || null;
   const a = parse(left);
   const b = parse(right);
   if (!a || !b) return 0;
@@ -340,7 +366,10 @@ function install({ root: rootOverride, force = false } = {}) {
   const previous = readManifest(root);
   const artifacts = desiredArtifacts(root, eos.coreRoot);
   const artifactPaths = new Set(artifacts.map((artifact) => artifact.relativePath));
-  const staleFiles = (previous?.files || []).filter((file) => !artifactPaths.has(file.path));
+  const staleFiles = [...new Map([
+    ...(previous?.files || []).filter((file) => !artifactPaths.has(file.path)),
+    ...legacyArtifactFiles(root),
+  ].map((file) => [file.path, file])).values()];
   const previousFiles = new Map((previous?.files || []).map((file) => [file.path, file.sha256]));
   const checkOwnership = (filePath, expectedHash) => {
     const target = safeArtifactTarget(root, filePath);
@@ -483,4 +512,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { descriptor, doctor, install, main, parseArgs, runtimeRoot, uninstall, update, githubLatestRelease, globalPrefix };
+module.exports = { descriptor, doctor, install, main, parseArgs, runtimeRoot, uninstall, update, githubLatestRelease, globalPrefix, compareVersions };

--- a/scripts/host-smoke.cjs
+++ b/scripts/host-smoke.cjs
@@ -148,7 +148,7 @@ try {
       .filter((command) => command.source === 'extension')
       .map((command) => [command.name, command]),
   );
-  for (const command of ['gsd', 'gsd-next', 'gsd-plan-phase', 'gsd-status']) {
+  for (const command of ['gsd', 'gsd-next', 'gsd-plan-phase', 'gsd-status', 'omp-native']) {
     assert.ok(extensionCommands.has(command), `OMP did not load extension command /${command}`);
   }
 

--- a/src/extension.cjs
+++ b/src/extension.cjs
@@ -615,11 +615,15 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     return activeGsdTaskIds.get(path.resolve(cwd))?.size || 0;
   }
 
+  function nativeTaskActivityIds(cwd) {
+    return [...(activeGsdTaskIds.get(path.resolve(cwd)) || [])].filter((taskId) => typeof taskId === 'string' && taskId);
+  }
+
   function nativeTaskActivityLines(count, chinese) {
     if (!count) return [];
     return [chinese
-      ? `OMP 原生任务运行中：${count} 个。请在任务与 Job 面板跟踪。`
-      : `Native GSD tasks running in OMP: ${count}. Track them in the task and Job panels.`];
+      ? `OMP 原生执行：${count} 个任务 · 使用 /omp-native 查看详情。`
+      : `OMP native execution: ${count} tasks · use /omp-native for details.`];
   }
 
 
@@ -1587,8 +1591,17 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     const recovery = activeTaskCount ? null : nativeTaskRecovery(cwd);
     const action = activeTaskCount || recovery ? null : readNextAction(cwd);
     const state = stateSnapshot(cwd);
+    const progress = state && !state.unreadable ? planProgress(cwd, state) : null;
     const checkpoint = !activeTaskCount && !recovery && !action ? resumableCheckpoint(cwd, state) : null;
     if (!state && !activeTaskCount && !action && !recovery && !checkpoint) return [];
+    const activeRow = activeTaskCount
+      ? widgetColor(WIDGET_COLORS.accent, chinese ? '● OMP 原生执行中' : '● OMP native execution active')
+      : null;
+    const progressRow = activeTaskCount && progress
+      ? widgetColor(WIDGET_COLORS.muted, chinese
+        ? `进度 ${progress.bar} ${localizedPlanProgress(progress, cwd, true)}`
+        : `Progress ${progress.bar} ${localizedPlanProgress(progress, cwd, true)}`)
+      : null;
     const recoveryCount = recovery?.failures.length || 0;
     const recoveryRow = recoveryCount
       ? widgetColor(WIDGET_COLORS.danger, chinese ? `⛔ ${recoveryCount} 个原生任务待恢复` : `⛔ Native task recovery: ${recoveryCount} failed`)
@@ -1597,27 +1610,31 @@ module.exports = function gsdPiExtension(pi, options = {}) {
       ? widgetColor(WIDGET_COLORS.warning, chinese ? `↻ 恢复阶段 ${checkpoint.phase}：${checkpoint.plansDone}/${checkpoint.plansTotal} 个计划已完成` : `↻ Resume Phase ${checkpoint.phase}: ${checkpoint.plansDone}/${checkpoint.plansTotal} plans complete`)
       : null;
     if (state?.unreadable) {
-      const rows = [recoveryRow].filter(Boolean);
+      const rows = [activeRow, recoveryRow].filter(Boolean);
       const lines = [widgetColor(WIDGET_COLORS.danger, chinese ? 'GSD · 状态文件无法解析' : 'GSD · state unreadable'), ...rows.map((row, index) => `${index === rows.length - 1 ? '└─' : '├─'} ${row}`)];
-      if (recoveryRow) lines.push(`   ${widgetColor(WIDGET_COLORS.muted, recovery.command)}`);
+      if (activeRow || recoveryRow) lines.push(`   ${widgetColor(WIDGET_COLORS.muted, activeRow ? '/omp-native' : recovery.command)}`);
       return lines;
     }
     const hasRisks = Boolean(state?.blockers || state?.concerns);
-    if (!hasRisks && !action && !recovery && !checkpoint) return [];
-    const heading = recovery
-      ? widgetColor(WIDGET_COLORS.danger, chinese ? 'GSD · 需要任务恢复' : 'GSD · Recovery needed')
-      : action
-        ? widgetColor(WIDGET_COLORS.accent, chinese ? 'GSD · 下一步' : 'GSD · Next Up')
-        : checkpoint
-          ? widgetColor(WIDGET_COLORS.warning, chinese ? 'GSD · 可恢复执行' : 'GSD · Resume available')
-          : widgetColor(WIDGET_COLORS.warning, chinese ? 'GSD · 需要关注' : 'GSD · Attention');
+    if (!hasRisks && !activeRow && !action && !recovery && !checkpoint) return [];
+    const heading = activeRow
+      ? widgetColor(WIDGET_COLORS.accent, chinese ? 'GSD · OMP 原生执行中' : 'GSD · OMP Native')
+      : recovery
+        ? widgetColor(WIDGET_COLORS.danger, chinese ? 'GSD · 需要任务恢复' : 'GSD · Recovery needed')
+        : action
+          ? widgetColor(WIDGET_COLORS.accent, chinese ? 'GSD · 下一步' : 'GSD · Next Up')
+          : checkpoint
+            ? widgetColor(WIDGET_COLORS.warning, chinese ? 'GSD · 可恢复执行' : 'GSD · Resume available')
+            : widgetColor(WIDGET_COLORS.warning, chinese ? 'GSD · 需要关注' : 'GSD · Attention');
     const rows = [];
     if (hasRisks) rows.push(widgetRiskLine(state, chinese));
+    if (activeRow) rows.push(activeRow);
+    if (progressRow) rows.push(progressRow);
     if (recoveryRow) rows.push(recoveryRow);
     if (checkpointRow) rows.push(checkpointRow);
     if (action) rows.push(action.label.slice(0, 92));
     const lines = [heading, ...rows.map((row, index) => `${index === rows.length - 1 ? '└─' : '├─'} ${row}`)];
-    const command = recovery?.command || (checkpoint ? '/gsd-resume-work' : action?.command);
+    const command = activeTaskCount ? '/omp-native' : recovery?.command || (checkpoint ? '/gsd-resume-work' : action?.command);
     if (command) lines.push(`   ${widgetColor(WIDGET_COLORS.muted, command)}`);
     return lines;
   }
@@ -1661,6 +1678,47 @@ module.exports = function gsdPiExtension(pi, options = {}) {
         ...recoveryLines,
         ...checkpointLines,
       ].join('\n');
+  }
+  function nativeToolAvailable(pi, toolName) {
+    if (typeof pi?.getAllTools !== 'function') return null;
+    try {
+      const tools = pi.getAllTools();
+      return Array.isArray(tools) && tools.some((tool) => tool?.name === toolName);
+    } catch {
+      return null;
+    }
+  }
+
+  function nativeStatusSummary(cwd, pi) {
+    const chinese = usesChinese(cwd);
+    const state = stateSnapshot(cwd);
+    const activeTaskIds = nativeTaskActivityIds(cwd);
+    const progress = state && !state.unreadable ? planProgress(cwd, state) : null;
+    const taskStatus = activeTaskIds.length
+      ? chinese ? `${activeTaskIds.length} 个任务运行中` : `${activeTaskIds.length} task${activeTaskIds.length === 1 ? '' : 's'} running`
+      : chinese ? '空闲，可开始执行' : 'Idle and ready';
+    const lines = [
+      'GSD · OMP Native',
+      chinese ? `状态：${taskStatus}` : `Status: ${taskStatus}`,
+    ];
+    if (progress) {
+      lines.push(chinese
+        ? `进度：${progress.bar} ${localizedPlanProgress(progress, cwd, true)}`
+        : `Progress: ${progress.bar} ${localizedPlanProgress(progress, cwd, true)}`);
+    }
+    const gsdInvoke = nativeToolAvailable(pi, 'gsd_invoke');
+    if (gsdInvoke !== null) {
+      lines.push(chinese
+        ? `gsd_invoke：${gsdInvoke ? '可用' : '当前上下文未挂载（/gsd 仍可用）'}`
+        : `gsd_invoke: ${gsdInvoke ? 'available' : 'not mounted in this context (/gsd remains available)'}`);
+    }
+    lines.push(chinese
+      ? '调度：OMP 原生 task → job；完成后使用 /gsd-next。'
+      : 'Dispatch: OMP native task → job; use /gsd-next after settlement.');
+    lines.push(chinese
+      ? '入口：/gsd-execute-phase <阶段> · /gsd-status'
+      : 'Entry points: /gsd-execute-phase <phase> · /gsd-status');
+    return lines.join('\n');
   }
 
   function widgetColor(code, text) {
@@ -2086,8 +2144,8 @@ The user explicitly selected the GSD action below. Execute it now, end-to-end, i
     await pi.sendMessage({
       customType: 'gsd-native-tasks-active',
       content: chinese
-        ? `OMP 中有 ${count} 个原生 GSD 任务正在运行。请使用任务与 Job 面板跟踪；任务结束后再推进下一步。`
-        : `${count} native GSD task${count === 1 ? ' is' : 's are'} running in OMP. Track it in the task and Job panels; advance after it settles.`,
+        ? `OMP 原生执行仍在进行（${count} 个任务）。使用 /omp-native 查看状态；完成后再执行 /gsd-next。`
+        : `OMP native execution is still running (${count} task${count === 1 ? '' : 's'}). Use /omp-native for status; run /gsd-next after settlement.`,
       display: true,
     }, { triggerTurn: false });
   }
@@ -3836,6 +3894,16 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
       await pi.sendMessage({
         customType: 'gsd-status-summary',
         content: localizedStatusSummary(ctx.cwd),
+        display: true,
+      }, { triggerTurn: false });
+    },
+  });
+  pi.registerCommand('omp-native', {
+    description: 'Show OMP-native GSD execution status and entry points.',
+    handler: async (_input, ctx) => {
+      await pi.sendMessage({
+        customType: 'omp-native-status',
+        content: nativeStatusSummary(ctx.cwd, pi),
         display: true,
       }, { triggerTurn: false });
     },

--- a/test/extension.test.cjs
+++ b/test/extension.test.cjs
@@ -50,7 +50,8 @@ function mockPi() {
     assert.equal(pi.commands.has('gsd'), true);
     assert.equal(pi.commands.has('gsd-next'), true);
     assert.equal(pi.commands.has('gsd-plan-phase'), true);
-    assert.equal(pi.commands.size >= 39, true);
+    assert.equal(pi.commands.size >= 40, true);
+    assert.equal(pi.commands.has('omp-native'), true);
     assert.equal(pi.tools.has('gsd_invoke'), true);
     assert.equal(pi.tools.get('gsd_invoke').loadMode, 'discoverable');
     assert.equal(pi.events.has('session_start'), true);
@@ -277,15 +278,40 @@ test('failed GSD task request releases tracked names', async () => {
 });
 
 
-test('does not render the low-signal active-task banner in the ordinary widget', async () => {
+test('renders concise OMP-native progress instead of a raw task-count banner', async () => {
   const root = gsdProjectRoot();
   try {
+    fs.writeFileSync(
+      path.join(root, '.planning', 'STATE.md'),
+      '---\nstatus: executing\nprogress:\n  total_plans: 4\n  completed_plans: 2\n---\nPhase: 2 of 3 (Build)\nStatus: executing\n',
+    );
     const pi = mockPi();
     extension(pi, { runtime: 'omp', runtimeRoot: root });
     const ctx = { cwd: root };
     await pi.events.get('tool_call')(taskSpawnCall('call_widget', ['Phase1Plan06Executor']), ctx);
-    const lines = extension._internals.widgetLines(root);
-    assert.equal(lines.some((line) => line.includes('个原生任务运行中') || line.includes('native task')), false);
+    const plain = extension._internals.widgetLines(root).join('\n').replace(/\u001b\[[0-9;]*m/g, '');
+    assert.match(plain, /GSD · OMP Native/);
+    assert.match(plain, /OMP native execution active/);
+    assert.match(plain, /Progress .*Plans 2\/4 complete/);
+    assert.match(plain, /\/omp-native/);
+    assert.doesNotMatch(plain, /native tasks running/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+test('omp-native reports native execution status and entry points', async () => {
+  const root = gsdProjectRoot();
+  try {
+    const sent = [];
+    const pi = mockPi();
+    pi.sendMessage = async (message) => { sent.push(message); };
+    extension(pi, { runtime: 'omp', runtimeRoot: root });
+    await pi.commands.get('omp-native').handler('', { cwd: root });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].customType, 'omp-native-status');
+    assert.match(sent[0].content, /GSD · OMP Native/);
+    assert.match(sent[0].content, /Dispatch: OMP native task/);
+    assert.match(sent[0].content, /\/gsd-execute-phase/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/installer.test.cjs
+++ b/test/installer.test.cjs
@@ -6,7 +6,8 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
-const { doctor, install, uninstall, update, parseArgs } = require('../bin/gsd-omp.cjs');
+const { doctor, install, uninstall, update, parseArgs, compareVersions } = require('../bin/gsd-omp.cjs');
+
 // Pin locale to English so the ownership-error regex stays deterministic
 // regardless of the dev shell's LANG.
 require('../src/locale.cjs').setLocale('en');
@@ -47,6 +48,19 @@ function sha256(value) {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+test('removes the stale legacy CJS extension during reinstall', () => {
+  const root = temporaryRoot('gsd-omp-legacy-extension');
+  const legacyPath = path.join(root, 'extensions', 'gsd-omp.cjs');
+  try {
+    install({ root });
+    fs.writeFileSync(legacyPath, '// GSD extension for Pi-compatible hosts\n');
+    install({ root });
+    assert.equal(fs.existsSync(legacyPath), false);
+    assert.equal(fs.existsSync(path.join(root, 'extensions', 'gsd-omp.ts')), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
  test('refuses to overwrite or remove a modified managed file', () => {
   const root = temporaryRoot('gsd-omp-ownership');
@@ -74,6 +88,11 @@ function sha256(value) {
   });
   assert.equal(result.upToDate, true);
   assert.equal(result.current, packageJson.version);
+});
+test('compares semantic release versions numerically', () => {
+  assert.equal(compareVersions('1.0.15', '1.0.12') > 0, true);
+  assert.equal(compareVersions('1.0.12', '1.0.15') < 0, true);
+  assert.equal(compareVersions('1.0.15', '1.0.15'), 0);
 });
 
 test('rejects a missing --root value instead of consuming another option', () => {


### PR DESCRIPTION
## Changes

- Fix numeric semantic-version comparison so `gsd-omp update` installs newer releases.
- Remove stale legacy CJS projections during reinstall when they match the known GSD extension signature.
- Replace the raw active-task widget with concise OMP-native status, plan progress, and `/omp-native` guidance.
- Add the `/omp-native` status command and host-smoke coverage.

## Verification

- `npm run prepack`
- `node scripts/host-smoke.cjs`
- Fresh OMP RPC discovery of `/omp-native`
- Local `gsd-omp doctor --json`
