### PR TITLE
fix: keep native execution internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The plugin also registers the `gsd_invoke` tool for structured access to the pub
 
 ## Commands
 
-The plugin registers 40 slash commands and the `gsd_invoke` tool. Commands are grouped by project lifecycle; descriptions are taken verbatim from the registered command metadata.
+The plugin registers 39 slash commands and the `gsd_invoke` tool. Commands are grouped by project lifecycle; descriptions are taken verbatim from the registered command metadata.
 
 
 ### Entry & status
@@ -64,7 +64,6 @@ The plugin registers 40 slash commands and the `gsd_invoke` tool. Commands are g
 | `/gsd-next` | Show or prepare the next localized GSD action |
 | `/gsd-progress` | Show GSD progress or advance through its gated next-step workflow |
 | `/gsd-status` | Show a localized GSD project summary |
-| `/omp-native` | Show OMP-native task execution status and entry points |
 | `/gsd <family> <subcommand> [args]` | Invoke the public `gsd-tools` CLI directly |
 
 ### Project lifecycle

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,7 +55,7 @@ gsd-omp install
 
 ## 命令
 
-插件注册了 40 个斜杠命令与 `gsd_invoke` 工具。下表按项目生命周期分组,描述取自命令注册元数据。
+插件注册了 39 个斜杠命令与 `gsd_invoke` 工具。下表按项目生命周期分组,描述取自命令注册元数据。
 
 
 ### 入口与状态
@@ -65,7 +65,6 @@ gsd-omp install
 | `/gsd-next` | 显示或准备下一个本地化的 GSD 动作 |
 | `/gsd-progress` | 显示 GSD 进度,或在门控的下一步工作流中推进 |
 | `/gsd-status` | 显示本地化的 GSD 项目摘要 |
-| `/omp-native` | 显示 OMP 原生任务执行状态与入口 |
 | `/gsd <family> <subcommand> [args]` | 直接调用公共 `gsd-tools` CLI |
 
 ### 项目生命周期

--- a/scripts/host-smoke.cjs
+++ b/scripts/host-smoke.cjs
@@ -148,9 +148,10 @@ try {
       .filter((command) => command.source === 'extension')
       .map((command) => [command.name, command]),
   );
-  for (const command of ['gsd', 'gsd-next', 'gsd-plan-phase', 'gsd-status', 'omp-native']) {
+  for (const command of ['gsd', 'gsd-next', 'gsd-plan-phase', 'gsd-status']) {
     assert.ok(extensionCommands.has(command), `OMP did not load extension command /${command}`);
   }
+  assert.equal(extensionCommands.has('omp-native'), false, 'OMP should not expose the internal omp-native command');
 
   const stateResponse = frames.find((frame) => frame.id === stateRequestId);
   assert.equal(stateResponse?.success, true, 'OMP did not return its RPC session state');

--- a/src/extension.cjs
+++ b/src/extension.cjs
@@ -615,15 +615,12 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     return activeGsdTaskIds.get(path.resolve(cwd))?.size || 0;
   }
 
-  function nativeTaskActivityIds(cwd) {
-    return [...(activeGsdTaskIds.get(path.resolve(cwd)) || [])].filter((taskId) => typeof taskId === 'string' && taskId);
-  }
 
   function nativeTaskActivityLines(count, chinese) {
     if (!count) return [];
     return [chinese
-      ? `OMP 原生执行：${count} 个任务 · 使用 /omp-native 查看详情。`
-      : `OMP native execution: ${count} tasks · use /omp-native for details.`];
+      ? `OMP 原生执行：${count} 个任务 · 使用 /gsd-status 查看详情。`
+      : `OMP native execution: ${count} tasks · use /gsd-status for details.`];
   }
 
 
@@ -1612,7 +1609,7 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     if (state?.unreadable) {
       const rows = [activeRow, recoveryRow].filter(Boolean);
       const lines = [widgetColor(WIDGET_COLORS.danger, chinese ? 'GSD · 状态文件无法解析' : 'GSD · state unreadable'), ...rows.map((row, index) => `${index === rows.length - 1 ? '└─' : '├─'} ${row}`)];
-      if (activeRow || recoveryRow) lines.push(`   ${widgetColor(WIDGET_COLORS.muted, activeRow ? '/omp-native' : recovery.command)}`);
+      if (activeRow || recoveryRow) lines.push(`   ${widgetColor(WIDGET_COLORS.muted, activeRow ? '/gsd-status' : recovery.command)}`);
       return lines;
     }
     const hasRisks = Boolean(state?.blockers || state?.concerns);
@@ -1634,7 +1631,7 @@ module.exports = function gsdPiExtension(pi, options = {}) {
     if (checkpointRow) rows.push(checkpointRow);
     if (action) rows.push(action.label.slice(0, 92));
     const lines = [heading, ...rows.map((row, index) => `${index === rows.length - 1 ? '└─' : '├─'} ${row}`)];
-    const command = activeTaskCount ? '/omp-native' : recovery?.command || (checkpoint ? '/gsd-resume-work' : action?.command);
+    const command = activeTaskCount ? '/gsd-status' : recovery?.command || (checkpoint ? '/gsd-resume-work' : action?.command);
     if (command) lines.push(`   ${widgetColor(WIDGET_COLORS.muted, command)}`);
     return lines;
   }
@@ -1679,48 +1676,6 @@ module.exports = function gsdPiExtension(pi, options = {}) {
         ...checkpointLines,
       ].join('\n');
   }
-  function nativeToolAvailable(pi, toolName) {
-    if (typeof pi?.getAllTools !== 'function') return null;
-    try {
-      const tools = pi.getAllTools();
-      return Array.isArray(tools) && tools.some((tool) => tool?.name === toolName);
-    } catch {
-      return null;
-    }
-  }
-
-  function nativeStatusSummary(cwd, pi) {
-    const chinese = usesChinese(cwd);
-    const state = stateSnapshot(cwd);
-    const activeTaskIds = nativeTaskActivityIds(cwd);
-    const progress = state && !state.unreadable ? planProgress(cwd, state) : null;
-    const taskStatus = activeTaskIds.length
-      ? chinese ? `${activeTaskIds.length} 个任务运行中` : `${activeTaskIds.length} task${activeTaskIds.length === 1 ? '' : 's'} running`
-      : chinese ? '空闲，可开始执行' : 'Idle and ready';
-    const lines = [
-      'GSD · OMP Native',
-      chinese ? `状态：${taskStatus}` : `Status: ${taskStatus}`,
-    ];
-    if (progress) {
-      lines.push(chinese
-        ? `进度：${progress.bar} ${localizedPlanProgress(progress, cwd, true)}`
-        : `Progress: ${progress.bar} ${localizedPlanProgress(progress, cwd, true)}`);
-    }
-    const gsdInvoke = nativeToolAvailable(pi, 'gsd_invoke');
-    if (gsdInvoke !== null) {
-      lines.push(chinese
-        ? `gsd_invoke：${gsdInvoke ? '可用' : '当前上下文未挂载（/gsd 仍可用）'}`
-        : `gsd_invoke: ${gsdInvoke ? 'available' : 'not mounted in this context (/gsd remains available)'}`);
-    }
-    lines.push(chinese
-      ? '调度：OMP 原生 task → job；完成后使用 /gsd-next。'
-      : 'Dispatch: OMP native task → job; use /gsd-next after settlement.');
-    lines.push(chinese
-      ? '入口：/gsd-execute-phase <阶段> · /gsd-status'
-      : 'Entry points: /gsd-execute-phase <phase> · /gsd-status');
-    return lines.join('\n');
-  }
-
   function widgetColor(code, text) {
     return `\u001b[${code}m${text}\u001b[0m`;
   }
@@ -2144,8 +2099,8 @@ The user explicitly selected the GSD action below. Execute it now, end-to-end, i
     await pi.sendMessage({
       customType: 'gsd-native-tasks-active',
       content: chinese
-        ? `OMP 原生执行仍在进行（${count} 个任务）。使用 /omp-native 查看状态；完成后再执行 /gsd-next。`
-        : `OMP native execution is still running (${count} task${count === 1 ? '' : 's'}). Use /omp-native for status; run /gsd-next after settlement.`,
+        ? `OMP 原生执行仍在进行（${count} 个任务）。使用 /gsd-status 查看状态；完成后再执行 /gsd-next。`
+        : `OMP native execution is still running (${count} task${count === 1 ? '' : 's'}). Use /gsd-status for status; run /gsd-next after settlement.`,
       display: true,
     }, { triggerTurn: false });
   }
@@ -3894,16 +3849,6 @@ Execute the complete \`${commandName}\` workflow for this user-supplied command 
       await pi.sendMessage({
         customType: 'gsd-status-summary',
         content: localizedStatusSummary(ctx.cwd),
-        display: true,
-      }, { triggerTurn: false });
-    },
-  });
-  pi.registerCommand('omp-native', {
-    description: 'Show OMP-native GSD execution status and entry points.',
-    handler: async (_input, ctx) => {
-      await pi.sendMessage({
-        customType: 'omp-native-status',
-        content: nativeStatusSummary(ctx.cwd, pi),
         display: true,
       }, { triggerTurn: false });
     },

--- a/test/extension.test.cjs
+++ b/test/extension.test.cjs
@@ -50,8 +50,8 @@ function mockPi() {
     assert.equal(pi.commands.has('gsd'), true);
     assert.equal(pi.commands.has('gsd-next'), true);
     assert.equal(pi.commands.has('gsd-plan-phase'), true);
-    assert.equal(pi.commands.size >= 40, true);
-    assert.equal(pi.commands.has('omp-native'), true);
+    assert.equal(pi.commands.size >= 39, true);
+    assert.equal(pi.commands.has('omp-native'), false);
     assert.equal(pi.tools.has('gsd_invoke'), true);
     assert.equal(pi.tools.get('gsd_invoke').loadMode, 'discoverable');
     assert.equal(pi.events.has('session_start'), true);
@@ -293,25 +293,8 @@ test('renders concise OMP-native progress instead of a raw task-count banner', a
     assert.match(plain, /GSD · OMP Native/);
     assert.match(plain, /OMP native execution active/);
     assert.match(plain, /Progress .*Plans 2\/4 complete/);
-    assert.match(plain, /\/omp-native/);
+    assert.match(plain, /\/gsd-status/);
     assert.doesNotMatch(plain, /native tasks running/);
-  } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-test('omp-native reports native execution status and entry points', async () => {
-  const root = gsdProjectRoot();
-  try {
-    const sent = [];
-    const pi = mockPi();
-    pi.sendMessage = async (message) => { sent.push(message); };
-    extension(pi, { runtime: 'omp', runtimeRoot: root });
-    await pi.commands.get('omp-native').handler('', { cwd: root });
-    assert.equal(sent.length, 1);
-    assert.equal(sent[0].customType, 'omp-native-status');
-    assert.match(sent[0].content, /GSD · OMP Native/);
-    assert.match(sent[0].content, /Dispatch: OMP native task/);
-    assert.match(sent[0].content, /\/gsd-execute-phase/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -339,6 +322,8 @@ test('gsd-next does not advance while a native GSD task is still running', async
     assert.equal(sent.length, 1, 'gsd-next emitted exactly one message');
     assert.equal(sent[0].customType, 'gsd-native-tasks-active',
       'gsd-next reports active tasks instead of dispatching the saved continuation');
+    assert.match(sent[0].content, /\/gsd-status/);
+    assert.doesNotMatch(sent[0].content, /\/omp-native/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Remove the accidental /omp-native user-facing command. Native task tracking remains internal, while progress and active-task notices point to the existing /gsd-status command.

Validation: npm test, npm run lint, node scripts/host-smoke.cjs.