### PR TITLE
docs: add project guides and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to `gsd-omp` are recorded here in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) style. The canonical changelog filename is **CHANGELOG.md**. See the [README](README.md) for the current installation and usage documentation.
+
+## [Unreleased]
+
+No unreleased changes recorded.
+
+## [1.0.20] - 2026-08-29
+
+### Added
+
+- Integrated OMP Goal Mode through the optional `goal_updated` event. When the host provides that event, the plugin mirrors the goal objective, status, and token budget in `/gsd-status`, the footer, the widget, and the live status overlay.
+- Restored the latest Goal Mode state from the OMP session journal when a session starts or reloads.
+
+### Changed
+
+- Added a continuation guard: while an active Goal Mode objective is running, GSD continuation prompts remain pending so the Goal Mode and GSD continuation loops do not compete. Pause or drop the goal before running `/gsd-next`.
+- Kept Goal Mode host-owned and optional. Hosts without `goal_updated`, including OMP 17, retain the rest of the GSD integration and simply omit this optional status surface.
+
+Related: [PR #57](https://github.com/tchivs/gsd-omp/pull/57), [release PR #58](https://github.com/tchivs/gsd-omp/pull/58).
+
+## [1.0.19] - 2026-08-29
+
+### Added
+
+- Deepened native OMP integration around `/gsd-status`, including native controls for context compaction, stopping the current turn, branching and navigating the session tree, switching sessions, and reloading runtime state.
+- Added OMP argument completion and session naming where projected skills expose stable parameter contracts.
+
+### Changed
+
+- Unified native task execution, context usage, compaction, retry, and asynchronous job state under the `/gsd-status` status surface, widget, footer, and overlay while keeping native task tracking internal.
+
+Related: [PR #55](https://github.com/tchivs/gsd-omp/pull/55), [release PR #56](https://github.com/tchivs/gsd-omp/pull/56).
+
+## [1.0.18] - 2026-08-29
+
+### Changed
+
+- Refined the OMP status widget layout with visual progress bars and clearer blocker and concern indicators.
+
+Related: [PR #53](https://github.com/tchivs/gsd-omp/pull/53), [release PR #54](https://github.com/tchivs/gsd-omp/pull/54).
+
+## [1.0.17] - 2026-08-29
+
+### Changed
+
+- Kept native task execution internal to the extension and removed the public `/omp-native` command.
+- Directed native execution status and continuation guidance to `/gsd-status`; host smoke coverage verifies that `/omp-native` is not exposed.
+
+Related: [PR #51](https://github.com/tchivs/gsd-omp/pull/51), [release PR #52](https://github.com/tchivs/gsd-omp/pull/52).
+
+[Unreleased]: https://github.com/tchivs/gsd-omp/compare/v1.0.20...HEAD
+[1.0.20]: https://github.com/tchivs/gsd-omp/releases/tag/v1.0.20
+[1.0.19]: https://github.com/tchivs/gsd-omp/releases/tag/v1.0.19
+[1.0.18]: https://github.com/tchivs/gsd-omp/releases/tag/v1.0.18
+[1.0.17]: https://github.com/tchivs/gsd-omp/releases/tag/v1.0.17

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to gsd-omp
+
+Thank you for contributing to `gsd-omp`, an MIT-licensed, independently maintained Oh My Pi host plugin for the GSD Embeddable Orchestration System. See [LICENSE](LICENSE) for the full license text.
+
+## Development environment
+
+- Node.js `>=24.0.0` is required.
+- The package is CommonJS and depends on `@opengsd/gsd-core` `^1.11.0`.
+- Oh My Pi with native ExtensionAPI support is needed for host integration work and the host smoke test.
+
+Clone the repository and install its development dependency:
+
+```bash
+git clone https://github.com/tchivs/gsd-omp.git
+cd gsd-omp
+npm install
+```
+
+## Required checks
+
+Run all required local checks before opening a pull request:
+
+```bash
+npm run lint
+npm test
+```
+
+Run the host smoke test against both OMP versions exercised by CI (`17.0.3` and `latest`). The following reproduces the CI setup for a local checkout without writing to the normal OMP profile:
+
+```bash
+package_tarball="$(npm pack --silent --ignore-scripts)"
+npm install --global "@oh-my-pi/pi-coding-agent@17.0.3"
+npm install --global "./${package_tarball}"
+OMP_VERSION=17.0.3 GSD_OMP_BIN=gsd-omp node scripts/host-smoke.cjs
+
+npm install --global "@oh-my-pi/pi-coding-agent@latest"
+OMP_VERSION=latest GSD_OMP_BIN=gsd-omp node scripts/host-smoke.cjs
+```
+
+The smoke script creates and removes its own temporary `PI_CODING_AGENT_DIR`. `npm pack` produces a local tarball; do not commit that file.
+
+## Branches and pull requests
+
+- Branch from `main`, which is the repository's integration branch.
+- No formal branch-name policy is documented. Existing branches use short descriptive prefixes such as `feat/`, `fix/`, `docs/`, and `chore/`; follow that pattern where it makes the purpose clear.
+- Keep each pull request focused. Describe the behavior or contract that changed, identify any compatibility considerations, and include the commands you ran and their results.
+- Run `npm run lint`, `npm test`, and the applicable OMP host smoke checks before requesting review. Do not report a check as passing unless it was run.
+- Update the relevant documentation when commands, installation, configuration, supported hosts, or user-visible behavior changes. Link related issues or pull requests when one exists.
+- There is no repository-published reviewer, approval-count, or commit-message policy. Use the GitHub pull request process and respond to the feedback recorded on the pull request.
+
+## Code style and repository hygiene
+
+- Keep the project CommonJS: use `require(...)`, `module.exports`, and the existing `.cjs` module layout.
+- When importing a Node.js built-in in new code, use the `node:` prefix (for example, `require('node:fs')` or `require('node:path')`).
+- Follow the surrounding style: two-space indentation, semicolons, single-quoted JavaScript strings, and trailing commas where the surrounding code uses them.
+- Preserve the OMP ExtensionAPI and GSD Host-Integration SDK contracts. Prefer the existing interfaces and patterns over introducing a second integration path.
+- Do not commit generated or local dependency artifacts, including `node_modules/`, `*.tgz`, or coverage output. These paths are ignored by the repository.
+
+## Documentation
+
+Keep the English and Chinese project entry points aligned when a user-visible change affects installation or usage:
+
+- [README.md](README.md) for the English overview and command reference.
+- [README.zh-CN.md](README.zh-CN.md) for the Chinese overview and command reference.
+- The linked guides under [`docs/`](docs/) for development, testing, architecture, configuration, and getting-started details.
+- [CHANGELOG.md](CHANGELOG.md), the canonical release history, for released behavior.
+
+Examples, commands, version requirements, environment-variable names, and links in documentation must match the current source and workflows.
+
+## Security issues
+
+Do not disclose vulnerability details, credentials, or an exploit proof in a public issue or pull request. This repository does not currently contain a `SECURITY.md` file or document a private reporting endpoint. Check the repository's GitHub **Security** tab for a private vulnerability-reporting option and use it only if the repository currently offers one. If no private route is available, contact the maintainer through a private contact route shown by the repository or owner at the time; do not publish sensitive details while waiting for instructions.
+
+A private report should include the affected version or commit, impact, reproduction steps or a minimal proof of concept, relevant Node.js/OMP versions, and any suggested mitigation. Remove secrets and personal data before sending it.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@
 
 This project is third-party software. It is not endorsed, reviewed, or maintained by OpenGSD.
 
+
+## Documentation
+
+| Guide | Purpose |
+|---|---|
+| [Getting Started](docs/GETTING-STARTED.md) | Install, verify, use, upgrade, and troubleshoot the plugin |
+| [Architecture](docs/ARCHITECTURE.md) | Runtime boundaries, data flow, projection, and OMP integration |
+| [Configuration](docs/CONFIGURATION.md) | Environment variables, CLI flags, manifest ownership, and Goal Mode coordination |
+| [Development](docs/DEVELOPMENT.md) | Local development, packaging, host smoke tests, and release workflow |
+| [Testing](docs/TESTING.md) | Unit-test and OMP host-validation guidance |
+| [Contributing](./CONTRIBUTING.md) | Contribution, pull-request, and documentation guidelines |
+| [CHANGELOG](./CHANGELOG.md) | Versioned release history |
+
 ## Requirements
 
 - Node.js 24 or newer

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,18 @@
 
 本项目为第三方软件，未由 OpenGSD 背书、审查或维护。
 
+## 文档
+
+| 文档 | 用途 |
+|---|---|
+| [入门指南](docs/GETTING-STARTED.md) | 安装、校验、使用、升级与故障排查 |
+| [架构说明](docs/ARCHITECTURE.md) | 运行时边界、数据流、投影和 OMP 集成 |
+| [配置参考](docs/CONFIGURATION.md) | 环境变量、CLI 参数、清单所有权与 Goal Mode 协调 |
+| [开发指南](docs/DEVELOPMENT.md) | 本地开发、打包、host smoke 与发布流程 |
+| [测试指南](docs/TESTING.md) | 单元测试和 OMP 宿主验证说明 |
+| [贡献指南](./CONTRIBUTING.md) | 贡献、Pull Request 与文档规范 |
+| [CHANGELOG](./CHANGELOG.md) | 按版本整理的发布历史 |
+
 ## 环境要求
 
 - Node.js 24 或更高版本

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,184 @@
+<!-- generated-by: gsd-doc-writer -->
+# Architecture
+
+## Scope
+
+This document describes the runtime architecture of `gsd-omp` v1.0.20: the installer and managed-file manifest, the GSD Embeddable Orchestration System (EoS) handshake, projection of GSD Core artifacts into an Oh My Pi (OMP) profile, the OMP extension lifecycle, localization, and the test/host-smoke boundaries. It is intended for maintainers tracing a change from the package entry point to an OMP session. It does not define GSD Core workflows or replace the authoritative command/skill content shipped by `@opengsd/gsd-core`.
+
+Relevant implementation paths:
+
+- `bin/gsd-omp.cjs` — CommonJS installer CLI, runtime-root resolution, manifest ownership, and update checks.
+- `src/eos.cjs` — EoS capability declaration and Host-Integration SDK negotiation.
+- `src/projection.cjs` — agent/skill projection and OMP-specific path/command rewriting.
+- `src/extension.cjs` — OMP ExtensionAPI factory, command/tool registration, lifecycle events, native status, task tracking, and optional Goal Mode adapter.
+- `src/locale.cjs` and `src/locales/*.cjs` — shell/EoS message locale selection and dictionaries.
+- `scripts/host-smoke.cjs` — isolated OMP integration exercise.
+- `.github/workflows/ci.yml` — Node unit/lint job and OMP host-smoke matrix.
+
+## System overview
+
+`gsd-omp` is a CommonJS package that binds the GSD Core public CLI and Host-Integration SDK to OMP's native extension surface. The installer projects a managed extension wrapper plus GSD agents and skills into an OMP runtime root; OMP then loads that wrapper and invokes the extension factory. At extension load time, the plugin negotiates EoS protocol 1 with GSD Core and exposes a programmatic CLI profile. During a session, OMP owns model selection, native task dispatch, approvals, session state, and isolation, while GSD Core owns its CLI semantics and filesystem artifacts. The main data path is filesystem projection → native OMP extension → child-process invocation of `gsd-tools.cjs` → displayed OMP message/status, with project state read from the planning workspace.
+
+The boundary is deliberate: this package adapts host interfaces but does not patch `gsd-core` source, implement a second GSD CLI, or replace OMP's native runtime. `src/eos.cjs` declares `runtime: 'bun'` as an EoS capability axis because that is the host contract; the extension invokes the resolved GSD CLI with Node's child-process API.
+
+## Component diagram
+
+```text
+                        npm package / @opengsd/gsd-core
+                                      |
+                                      v
++-------------------+       +-------------------+       +----------------------+
+| bin/gsd-omp.cjs   |------>| src/eos.cjs       |------>| Host-Integration SDK |
+| install/update/...|       | axes + handshake  |       | protocol 1           |
++---------+---------+       +-------------------+       +----------+-----------+
+          |                                                       |
+          | buildProjectedArtifacts                              | adapters
+          v                                                       v
++-------------------+       loads wrapper       +-----------------------------+
+| OMP runtime root  |-------------------------->| src/extension.cjs          |
+| extensions/       |                           | commands/tool/events/UI   |
+| agents/ skills/   |                           +------+----------------------+
+| manifest          |                                  |
++-------------------+                                  | spawn with
+                                                       | GSD_RUNTIME=omp
+                                                       v
+                                             +-----------------------------+
+                                             | gsd-core/bin/gsd-tools.cjs |
+                                             | project state + artifacts  |
+                                             +--------------+--------------+
+                                                            |
+                                                            v
+                                             OMP messages, widget, status,
+                                             native tasks and session state
+```
+
+## Installer and manifest
+
+`bin/gsd-omp.cjs` is the package's executable (`package.json` maps the `gsd-omp` bin to this file). It supports `install`, `uninstall`, `doctor`, `descriptor`, and `update`; with no command, `install` is selected. `--root PATH` is resolved to an absolute path and takes precedence over `PI_CODING_AGENT_DIR`; otherwise the root is `$PI_CODING_AGENT_DIR` or `~/.omp/agent`.
+
+An install performs these steps:
+
+1. Resolve `@opengsd/gsd-core` and run `Eos.initialize()`.
+2. Reject a bundled GSD Core version below `1.11.0`.
+3. Build `extensions/gsd-omp.ts`, a thin OMP module wrapper that imports `src/extension.cjs` and passes `{ runtime: "omp", runtimeRoot }`.
+4. Project every `gsd-*.md` agent and every `gsd-*` skill with a `SKILL.md` from the resolved core tree.
+5. Stage all files in a temporary transaction directory, replace prior targets only after ownership checks, and write `.gsd-omp-manifest.json`.
+6. Remove unchanged stale managed projections and recognized legacy CJS extensions. Modified stale files remain protected.
+
+The manifest is a version-1 JSON object containing `schemaVersion`, `plugin`, package `version`, `enginesGsd`, negotiated `protocolVersion`, resolved `coreVersion`, EoS `profile`, `installedAt`, and a `files` array. Each file entry contains a relative `path` and SHA-256 `sha256`. Manifest paths must remain relative, unique, within the runtime root, and point through regular directory components; symlinked parents are rejected.
+
+Ownership is hash-based. Reinstall/update refuses to overwrite a missing-manifest file or a managed file whose current hash differs from the recorded hash. Uninstall removes only unchanged regular files listed in the manifest and preserves modified or directory replacements; it keeps the manifest if anything is skipped. `--force` intentionally bypasses the hash mismatch check, but it does not bypass path-safety checks or permit a symlink traversal. This protects an OMP profile that contains user edits.
+
+`update` obtains the latest release metadata, installs a newer package globally with npm, then invokes the newly installed `gsd-omp install` so the new process projects the new extension, agents, skills, and bundled core. If the installed version is current, it reports that no projection update is needed. The external release lookup is implemented in `githubLatestRelease()` using the repository's GitHub API/latest-release page fallback. <!-- VERIFY: GitHub is an external release service; confirm network and organization policy before relying on it. -->
+
+## EoS handshake and responsibility boundary
+
+`src/eos.cjs` resolves the package location of `@opengsd/gsd-core`, loads `gsd-core/bin/lib/host-integration-sdk.cjs`, builds a handshake request using the SDK protocol constant and `OMP_AXES`, and immediately handles that request. Initialization rejects any result whose profile is not `programmatic-cli` or whose negotiated protocol is not the integer `1`.
+
+The declared axes are:
+
+| Axis | Value or contract |
+|---|---|
+| `embeddingMode` | `imperative` |
+| `commandSurface` | `slash-programmatic` |
+| `dispatch` | named and nested to depth 2; background dispatch; full subagent toolkit; `isolation: none` in the EoS declaration |
+| `modelMode` | `passive` — OMP remains the model authority |
+| `hookBus` | `host` — lifecycle events come from OMP |
+| `stateIO` | `filesystem` |
+| `transport` | `native-extension` |
+| `runtime` | `bun` (the declared host capability) |
+| `effortSurface` | `none` |
+
+The initialized adapter bundle contains the imperative adapter (`runtime: 'omp'`), passive model adapter, host hook bus, and filesystem state adapter. The extension uses these negotiated capabilities as the compatibility contract, then invokes the public GSD CLI path resolved beneath the installed core tree.
+
+Responsibilities are intentionally separate:
+
+- **OMP** owns session lifecycle, the active model, native `task` jobs, job settlement, approvals, context compaction, retry/stop controls, session branching/switching, and isolation. A native task with `isolated: true` is OMP's isolation primitive.
+- **GSD Core** owns the `gsd-tools.cjs` command families, project/planning artifacts, agent and skill source content, and GSD-specific state transitions.
+- **gsd-omp** translates between them: it supplies OMP command handlers, passes `GSD_RUNTIME=omp` and the agent directory to child processes, tracks native task activity, renders status, and forwards hook decisions. It does not invent a replacement public GSD API.
+
+The EoS `dispatch.isolation: 'none'` value must not be read as a request to disable OMP isolation. It describes the adapter's generic dispatch capability; projected execution instructions use OMP's native `task` and request `isolated: true` where repository changes require it.
+
+## Artifact projection
+
+`src/projection.cjs` reads the resolved GSD Core `agents/`, `skills/`, and `commands/gsd/` directories. It computes the available command names from the core command files and rewrites source content for OMP:
+
+- Agent frontmatter is validated for `name` and `description`, then rebuilt with OMP's tool list (`read, write, edit, bash, glob, grep, lsp, web_search, task`) and `spawns: "*"`.
+- GSD Core paths such as `~/.claude/gsd-core` and `~/.claude` are rewritten to the resolved core/runtime paths.
+- `gsd:<command>` references are rewritten to OMP's `gsd-<command>` command spelling.
+- Projected agents receive the OMP native orchestration guidance. The executor additionally receives the OMP task-result lifecycle line contract.
+- Projected skills receive an `<omp_runtime_cli>` block identifying the authoritative `gsd-tools.cjs` path, `GSD_RUNTIME=omp`, and the projected agents directory. Existing copies of that block are not duplicated.
+
+The installer places the resulting files under `agents/` and `skills/` below the runtime root. The source files remain in the installed GSD Core package; projection is generated output, not a second source of truth.
+
+## OMP extension lifecycle and command surface
+
+The installed wrapper loads `src/extension.cjs` through CommonJS and calls the exported extension factory with the OMP `ExtensionAPI` object. The factory requires a Zod-capable API, initializes EoS, resolves the engine root/CLI, and derives `runtimeRoot` from the installer-provided option (falling back to `~/.omp/agent` for a directly loaded extension). It sets `GSD_AGENTS_DIR` only when the host did not already define it; the default is `<runtimeRoot>/agents`.
+
+At registration time the extension:
+
+- discovers projected skills through `resources_discover`;
+- registers the projected skill commands plus OMP-native handlers for the core GSD command surface (including `gsd`, `gsd-status`, `gsd-next`, lifecycle, planning, execution, review, audit, workspace, and fast-path entries);
+- registers the discoverable `gsd_invoke` tool with Zod parameters `family`, `subcommand`, `args`, and optional `raw`;
+- registers custom GSD message renderers when OMP exposes `registerMessageRenderer` and `pi.Text`;
+- registers `Ctrl+Shift+G` and the `--gsd-status` flag when those OMP registration methods exist; and
+- registers the OMP event handlers described below.
+
+`/gsd <family> <subcommand> [args]` is a thin programmatic route. The extension parses quote-aware arguments, spawns the resolved `gsd-tools.cjs` with the current project as `cwd`, and returns bounded stdout/stderr in a native message. `gsd_invoke` exposes the same child-process path to structured tool callers. Missing CLI resolution returns a structured unsuccessful result rather than silently invoking another executable.
+
+The extension also invokes selected GSD hook scripts on `tool_call` (`Write`/`Edit`/`Bash` as applicable). Hook subprocesses are bounded and fail open on missing hooks, spawn errors, malformed output, or timeout; a hook may still block a call through its explicit decision. This keeps hook checks from blocking OMP's event loop while preserving their advisory/blocking boundary.
+
+Lifecycle event handling is project-scoped (the extension first checks whether the current directory has a recognizable planning workspace):
+
+- `session_start` schedules one-time onboarding when `response_language` is absent, refreshes status, optionally opens the `--gsd-status` overlay, and shows a workflow-guard reminder.
+- `session_switch`, `session_branch`, `session_tree`, and `session_compact` refresh status and clear context-local Goal Mode state where appropriate.
+- `auto_compaction_start/end`, `auto_retry_start/end`, and `session_stop` expose transient native runtime signals in status.
+- `message_end` extracts pending next-action/checkpoint records from assistant text and persists them in the planning workspace.
+- `tool_execution_start/update/end`, `tool_result`, and `tool_call` track native GSD task IDs, progress, failures, settlement, hook decisions, and guarded repository writes.
+- `session_shutdown` clears context and project runtime tracking.
+
+## Status surface and optional Goal Mode adapter
+
+`/gsd-status` is the single user-facing GSD status command. Without a control argument it combines a localized project summary with native context usage, compaction/retry/stop signals, running async task counts, and (when available) Goal Mode state. `--compact` asks OMP to compact context after confirmation; `--stop`/`--abort` asks OMP to abort after confirmation. Native session controls accept `--reload`, `--branch ENTRY_ID`, `--tree ENTRY_ID [--summarize]`, and `--switch SESSION_PATH`, subject to confirmation where required.
+
+The same status data feeds the `gsd` widget above the editor and the live overlay opened by `Ctrl+Shift+G` or the `--gsd-status` flag. The overlay refreshes periodically and supports `Esc`/Enter to close and `e` to load the pending next action into OMP's editor. Native task tracking remains internal to the extension; status is the display surface.
+
+Goal Mode is an optional host capability, not a replacement for GSD continuation. The extension attempts to register `goal_updated` inside a guarded `try` block. For each event it accepts either `event.state` or an `event.goal` shape, validates objective/status/token fields, and mirrors the normalized objective, status, token usage/budget, and time usage into status/widget/overlay output. On session start/reload-related state refresh, it can reconstruct the latest state from `sessionManager.getEntries()` by reading the most recent `mode_change` entry with `mode: 'goal'` or `mode: 'goal_paused'`.
+
+When a goal is active (`enabled === true` and goal status `active`), the extension holds a pending GSD continuation rather than competing with OMP's Goal Mode loop. The user should run `/goal pause` or `/goal drop` before running `/gsd-next`; stopping a turn follows OMP's native Goal Mode behavior, while detached native tasks remain tracked. OMP 17 has no `goal_updated` event: registration is caught, and all other commands, status, task tracking, and filesystem integration remain available without the optional Goal Mode display/coordination surface.
+
+## Localization
+
+`src/locale.cjs` handles messages emitted by the shell CLI and EoS bootstrap. It resolves the first non-empty value in this order: `GSD_OMP_LOCALE`, `LC_ALL`, `LC_MESSAGES`, `LANG`. Values whose lowercased form starts with `zh` select `zh-CN`; all other values select `en`. Missing dictionary keys fall back to English, and unknown placeholders remain unchanged.
+
+The in-session extension uses the project planning config's `response_language` instead. On the first interactive session for a project without that field, onboarding offers Simplified Chinese or English and writes the selected value to `.planning/config.json`; the optional interaction-style selection can also write `workflow.text_mode`. This separation prevents a shell locale from unexpectedly changing an already configured project session.
+
+## Tests and host-smoke boundary
+
+Unit tests live under `test/` and exercise installer ownership/manifest safety, EoS negotiation, projection rewriting, extension helpers, and locale selection. `npm test` runs Node's built-in test runner; `npm run lint` runs `node --check` across the CommonJS sources. These are package-level checks and do not prove that a particular installed OMP release accepts the extension API.
+
+`scripts/host-smoke.cjs` is the integration boundary. It creates a temporary `PI_CODING_AGENT_DIR`, installs the package into that isolated root, runs JSON `install`, `doctor`, and `descriptor`, starts OMP in RPC mode against the repository, verifies readiness and representative extension commands (`gsd`, `gsd-next`, `gsd-plan-phase`, `gsd-status`), checks the `gsd_invoke` exposure according to host behavior, and uninstalls the projection. It supplies a placeholder `OPENAI_API_KEY` only for host startup when no key is present; it does not perform a model request.
+
+CI runs the Node 24 unit job (`npm ci`, `npm run lint`, `npm test`) first, then the host-smoke job against OMP `17.0.3` and `latest` with Bun installed. The matrix deliberately keeps Goal Mode optional: the pinned OMP 17 path must remain healthy without `goal_updated`, while newer hosts may expose the additional adapter event. The host smoke test is not a substitute for testing GSD Core's own workflows or OMP's complete native UI.
+
+## Maintainer tracing examples
+
+Inspect the negotiated contract and verify the installed projection without modifying the default profile:
+
+```bash
+root="$(mktemp -d)"
+PI_CODING_AGENT_DIR="$root" gsd-omp install --json
+PI_CODING_AGENT_DIR="$root" gsd-omp descriptor --json
+PI_CODING_AGENT_DIR="$root" gsd-omp doctor --json
+PI_CODING_AGENT_DIR="$root" gsd-omp uninstall --json
+rm -rf "$root"
+```
+
+To trace a command from OMP to GSD Core, start OMP in a GSD project and use the programmatic route; the extension will execute the resolved core CLI rather than a global `gsd-tools` on `PATH`:
+
+```text
+/gsd query help
+/gsd-status
+```
+
+To inspect the exact projection implementation, begin at `bin/gsd-omp.cjs:desiredArtifacts()`, follow `buildProjectedArtifacts()` in `src/projection.cjs`, then follow `invokeAsync()` and the `pi.registerCommand()` calls in `src/extension.cjs`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,214 @@
+<!-- generated-by: gsd-doc-writer -->
+# Configuration
+
+## Scope
+
+This document covers configuration that affects the `gsd-omp` installer and its OMP extension: runtime-root selection, projected-agent lookup, shell and project-session localization, installer arguments, manifest ownership, and optional OMP Goal Mode coordination. It targets maintainers and operators of `gsd-omp` v1.0.20. GSD Core's complete project configuration schema remains owned by `@opengsd/gsd-core`; only fields read by this plugin are described here.
+
+Relevant implementation paths:
+
+- `bin/gsd-omp.cjs` — CLI parsing, runtime root, manifest validation, ownership checks, and update behavior.
+- `src/extension.cjs` — OMP runtime root/agent lookup, `gsd-tools` environment, project config reads, status, lifecycle events, and Goal Mode coordination.
+- `src/locale.cjs` — POSIX locale precedence and normalization.
+- `src/locales/en.cjs` and `src/locales/zh-CN.cjs` — shell/EoS message dictionaries.
+- `src/eos.cjs` — negotiated EoS values that are fixed by the adapter rather than user configuration.
+- `scripts/host-smoke.cjs` — isolated test environment variables and runtime-root setup.
+
+## Runtime root
+
+The runtime root is the directory into which the installer writes OMP artifacts. Resolution is performed by `runtimeRoot()` in `bin/gsd-omp.cjs`:
+
+1. The `--root PATH` CLI option, when supplied, wins.
+2. Otherwise `PI_CODING_AGENT_DIR` is used.
+3. Otherwise the default is `~/.omp/agent` (with the home directory resolved by Node).
+
+The path is resolved to an absolute path. A normal installed layout is:
+
+```text
+<runtime-root>/
+├── .gsd-omp-manifest.json
+├── extensions/gsd-omp.ts
+├── agents/gsd-*.md
+└── skills/gsd-*/SKILL.md
+```
+
+`PI_CODING_AGENT_DIR` controls where the installer writes. It does not, by itself, change where GSD Core looks for agents during an already running extension. The extension receives the install-time root in the generated wrapper and defaults its own direct-load root to `~/.omp/agent`.
+
+The extension derives its default agent directory as `<runtime-root>/agents`. If `GSD_AGENTS_DIR` was already present when OMP loaded the extension, that explicit value wins and is used as-is. Otherwise the extension sets `GSD_AGENTS_DIR` to the derived directory. This distinction permits operators who manage agent projections separately to point GSD Core at another directory without the plugin replacing it.
+
+## Environment variables
+
+### Runtime and localization variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `PI_CODING_AGENT_DIR` | Optional | `~/.omp/agent` | Installer runtime root when `--root` is not supplied. The host smoke script sets this to a temporary directory. |
+| `GSD_AGENTS_DIR` | Optional | `<runtime-root>/agents` | Directory passed to every extension-launched `gsd-tools.cjs` process. An existing value is preserved; otherwise the extension exports its derived default. |
+| `GSD_OMP_LOCALE` | Optional | Next POSIX locale or `en` | Explicit locale for installer CLI and EoS bootstrap messages. Values beginning with `zh` normalize to `zh-CN`; all other values normalize to `en`. |
+| `LC_ALL` | Optional | Next POSIX locale or `en` | First POSIX fallback after `GSD_OMP_LOCALE`. |
+| `LC_MESSAGES` | Optional | Next POSIX locale or `en` | Second POSIX fallback after `GSD_OMP_LOCALE` and `LC_ALL`. |
+| `LANG` | Optional | `en` | Final POSIX locale fallback after `GSD_OMP_LOCALE`, `LC_ALL`, and `LC_MESSAGES`. |
+
+The effective shell/EoS locale is selected in this exact order: `GSD_OMP_LOCALE`, `LC_ALL`, `LC_MESSAGES`, `LANG`. Supported dictionaries are `en` and `zh-CN`; a value such as `zh_CN.UTF-8` selects `zh-CN`, while an unknown or empty value falls back to English. This locale does not override a project's in-session language setting.
+
+### Update and smoke-test variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GITHUB_TOKEN` | Optional | Unset | If present, the update release lookup sends it as a Bearer token. It is not required for normal public-release lookup. |
+| `GH_TOKEN` | Optional | Unset | Fallback token name used when `GITHUB_TOKEN` is not present. |
+| `OMP_BIN` | Smoke-test only | `omp` | Executable selected by `scripts/host-smoke.cjs` to launch OMP. Not read by the installed extension. |
+| `GSD_OMP_BIN` | Smoke-test only | Run `bin/gsd-omp.cjs` with the current Node executable | Optional installer executable selected by `scripts/host-smoke.cjs`. |
+| `OMP_VERSION` | CI/smoke-test only | `local` in output | Labels the OMP version in the host-smoke result and selects the legacy OMP 17 fallback branch. It is not an extension configuration setting. |
+| `OPENAI_API_KEY` | Smoke-test only | `not-a-real-key` for host startup | The smoke script passes an existing key through, or supplies a placeholder so host startup can be exercised without a real request. Do not use the placeholder for an actual model call. |
+
+The extension itself sets `GSD_RUNTIME=omp` for each child `gsd-tools.cjs` invocation. This is an internal bridge variable, not a user setting; callers should not depend on changing it through the shell. The EoS descriptor's `runtime: "bun"` is a negotiated capability declaration and is not an environment-variable override.
+
+## Project configuration
+
+The extension reads the active planning workspace's `config.json`, normally `.planning/config.json`, through the resolved GSD Core planning-path helper. It parses JSON and treats an unreadable or absent file as unavailable configuration rather than inventing values. Onboarding writes a temporary file and atomically renames it, preserving existing keys.
+
+The plugin consumes these fields:
+
+| Path | Type | Effect |
+|---|---|---|
+| `response_language` | string | Selects in-session extension messages. Values matching `zh`, `Chinese`, or `中文` (case-insensitive) use Simplified Chinese; all other values use English. |
+| `workflow.text_mode` | boolean | Preserved and optionally set by first-session onboarding when the user chooses terminal text versus OMP interactive controls. |
+| `hooks.workflow_guard` | truthy value | Enables a session-start reminder derived from the current state file. Hook execution itself is handled by GSD Core hook files and is bounded/fail-open by the extension. |
+| `graphify.enabled` | boolean | Enables the graphify integration gate when combined with `graphify.auto_update`. |
+| `graphify.auto_update` | boolean | Allows the extension to start a background `graphify` rebuild after a successful, HEAD-advancing command on the configured default branch. The rebuild is disabled in CI. |
+
+A minimal project-language example is:
+
+```json
+{
+  "response_language": "English",
+  "workflow": {
+    "text_mode": false
+  }
+}
+```
+
+To select Simplified Chinese explicitly, use `"response_language": "Simplified Chinese"`. The first interactive `session_start` for a GSD project with no `response_language` offers `Simplified Chinese` or `English`; it can also ask for interaction style if `workflow.text_mode` is not already explicit. Projects without an interactive UI do not receive that picker.
+
+## Installer CLI configuration
+
+The executable accepts one command followed by common options:
+
+```text
+gsd-omp [install|update|uninstall|doctor|descriptor] [--root <path>] [--force] [--json]
+```
+
+With no command, the CLI behaves as `install`. `--help`/`-h` prints usage. `--root` requires a following path and is normalized to an absolute path; a missing value or unknown argument is an error. `--json` prints the command result as JSON. The supported commands are:
+
+| Command | Behavior | Useful result fields |
+|---|---|---|
+| `install` | Negotiate EoS, validate GSD Core, project the wrapper/agents/skills, and update the manifest transactionally. | `root`, `manifestPath`, `installed`, `coreVersion`, `protocolVersion` |
+| `update` | Resolve a newer public release, globally install it with npm, then run the newly installed CLI's `install` projection. | `updated`/`upToDate`, `from`, `to`, `current`, `latest`, `root` |
+| `uninstall` | Remove unchanged files listed in the manifest and remove the manifest only when no files are skipped. | `root`, `removed`, `skipped`, `absent` |
+| `doctor` | Check manifest presence, missing/modified projected files, and EoS profile. | `ok`, `installed`, `version`, `coreVersion`, `protocolVersion`, `profile`, `missing`, `modified` |
+| `descriptor` | Print the negotiated plugin identity, EoS axes, interface points, and protocol/core requirement. | `id`, `protocolVersion`, `enginesGsd`, `profile`, `interfacePoints`, `axes` |
+
+`doctor` returns a failing process status when the installation is absent/unhealthy. `uninstall` returns a failing process status if any managed file was skipped. These status rules make the JSON form suitable for a deployment or dotfiles check without treating a modified user file as silently removed.
+
+Examples:
+
+```bash
+# Use a disposable profile; no files are written to the normal OMP root.
+root="$(mktemp -d)"
+PI_CODING_AGENT_DIR="$root" gsd-omp install --json
+PI_CODING_AGENT_DIR="$root" gsd-omp doctor --json
+PI_CODING_AGENT_DIR="$root" gsd-omp descriptor --json
+PI_CODING_AGENT_DIR="$root" gsd-omp uninstall --json
+rm -rf "$root"
+```
+
+```bash
+# Use an explicit root; this overrides PI_CODING_AGENT_DIR.
+gsd-omp install --root "$HOME/.omp/agent" --json
+```
+
+Do not put access tokens or other secrets in the generated wrapper, projected skills, or manifest. If update authentication is needed, provide `GITHUB_TOKEN` or `GH_TOKEN` through the process environment/secret manager rather than writing it to project files. The update endpoint and latest-release fallback are external GitHub infrastructure defined by `githubLatestRelease()`; confirm network and organization policy before relying on them. <!-- VERIFY: GitHub is an external release service; confirm network and organization policy before relying on it. -->
+
+## Manifest ownership and `--force`
+
+`.gsd-omp-manifest.json` is the ownership record, not a general OMP configuration file. The installer records SHA-256 hashes for every generated file. On reinstall, stale manifest entries and recognized legacy extension files are considered for removal, but each target is checked first. A target is safe only when it is a regular file with the expected hash; path components must be real directories, not symlinks.
+
+Normal behavior is intentionally conservative:
+
+- A missing or changed target is not overwritten.
+- An unmanaged file at a desired target is protected.
+- An invalid manifest (wrong schema/plugin, duplicate path, absolute/parent-traversing path, or invalid hash) stops the operation.
+- Uninstall preserves modified files and keeps the manifest when cleanup is incomplete.
+- `--force` permits replacement/removal despite a hash mismatch, but still rejects unsafe manifest paths, symlinked parents, directories in place of files, and invalid manifests.
+
+Use `--force` only when the operator has reviewed and intentionally wants to replace or delete local changes in GSD-owned projections:
+
+```bash
+gsd-omp install --force
+# or, after reviewing the projected files:
+gsd-omp uninstall --force
+```
+
+A safer refresh is to run `gsd-omp doctor --json` first and inspect `missing`/`modified`; do not use `--force` merely to silence a warning.
+
+## OMP Goal Mode coordination
+
+Goal Mode support is optional and host-dependent. The extension attempts to register the OMP `goal_updated` event in a guarded block. OMP 17 does not expose this event, so the registration failure is caught and the normal command, task, status, and localization surfaces continue to work.
+
+When the event exists, the adapter accepts either `event.state` or an `event.goal` payload and validates a goal containing at least a non-empty `objective`, a `status`, and finite non-negative `tokensUsed`. It also preserves optional finite positive `tokenBudget`, finite non-negative `timeUsedSeconds`, string `id`, and numeric `updatedAt`. The normalized state is displayed by `/gsd-status`, the GSD widget, and the live status overlay. On state refresh, the extension can recover the latest goal from the session journal's most recent `mode_change` entry whose mode is `goal` or `goal_paused`.
+
+Coordination rule:
+
+1. If Goal Mode is active (`enabled === true` and goal status is `active`), a pending GSD continuation is held rather than automatically started.
+2. The user pauses or drops the OMP goal with `/goal pause` or `/goal drop`.
+3. The user then runs `/gsd-next` when it is safe for the GSD continuation to proceed.
+
+This prevents two continuation loops from competing. It does not take ownership of OMP's GoalRuntime, alter the goal, or make Goal Mode a prerequisite for GSD. A stop request still uses OMP's native abort behavior; detached native tasks remain tracked. On OMP 17, omit assumptions about goal status/events and use the rest of the integration normally.
+
+## Safe operational patterns
+
+Use an isolated root while testing installer changes or a new OMP version:
+
+```bash
+set -eu
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+PI_CODING_AGENT_DIR="$root" GSD_OMP_LOCALE=en gsd-omp install --json
+PI_CODING_AGENT_DIR="$root" GSD_OMP_LOCALE=en gsd-omp doctor --json
+```
+
+Use a separate, explicit agent directory only when the projected agents are managed there already:
+
+```bash
+GSD_AGENTS_DIR="$HOME/.omp/managed-gsd-agents" omp
+```
+
+The extension preserves that value and passes it to GSD Core. Ensure the directory contains the projected `gsd-*.md` files before starting a project session; otherwise GSD Core's agent availability checks can report them missing.
+
+For a project-local language override without changing the shell's CLI language:
+
+```json
+{
+  "response_language": "English"
+}
+```
+
+For shell-only Chinese installer output:
+
+```bash
+GSD_OMP_LOCALE=zh_CN.UTF-8 gsd-omp doctor --json
+```
+
+## Fixed adapter settings
+
+These are not user-configurable environment values. `src/eos.cjs` negotiates them on each process's first EoS initialization and caches the result:
+
+- protocol version `1`;
+- profile `programmatic-cli`;
+- model mode `passive` (OMP controls the session model);
+- host hook bus and filesystem state I/O;
+- native-extension transport; and
+- the declared dispatch capabilities, including named nested/background dispatch and `isolation: none` in the EoS axes.
+
+The last value describes the generic adapter declaration. Native OMP task isolation remains governed by OMP and the projected command/agent instructions; changing model profiles or adding an environment override does not turn the EoS adapter into a per-agent model router.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,120 @@
+<!-- generated-by: gsd-doc-writer -->
+# Development
+
+This guide covers local work on `gsd-omp`, an independently maintained CommonJS OMP extension plugin. End-user installation and recovery steps are in [Getting Started](GETTING-STARTED.md); the module boundaries are documented in [Architecture](ARCHITECTURE.md).
+
+## Local setup
+
+The package requires Node.js `>=24.0.0` and resolves `@opengsd/gsd-core` from the package dependency (`^1.11.0`). From a checkout:
+
+```bash
+git clone https://github.com/tchivs/gsd-omp.git
+cd gsd-omp
+npm install
+```
+
+Use `npm install` for an editable development checkout. CI uses the lockfile-reproducible form:
+
+```bash
+npm ci
+```
+
+The repository has no `.env` setup step. Keep host experiments isolated from a developer's OMP profile by choosing a temporary runtime root:
+
+```bash
+PI_CODING_AGENT_DIR="$(mktemp -d)" node bin/gsd-omp.cjs install
+```
+
+The installer defaults to `~/.omp/agent` when `PI_CODING_AGENT_DIR` is absent. The extension wrapper receives that runtime root and projected skills are discovered from its `skills/` directory.
+
+## Build, lint, and test commands
+
+`package.json` defines the following developer-facing commands:
+
+| Command | Description |
+|---|---|
+| `npm install` | Install dependencies for an editable checkout. |
+| `npm ci` | Install exactly the versions in `package-lock.json`; used by CI. |
+| `npm run lint` | Run `node --check` against the CLI and every CommonJS source/locale module. |
+| `npm test` | Run the Node.js built-in test runner (`node --test`) across `test/`. |
+| `npm pack --silent --ignore-scripts` | Create a package tarball without running lifecycle scripts; used to test the packed artifact. |
+
+`prepack` is also defined as `npm run lint && npm test`. A normal pack that runs lifecycle scripts therefore validates syntax and tests before packing; the host smoke workflow intentionally uses `--ignore-scripts` and runs its own checks.
+
+## Packed-package and host smoke workflow
+
+To test what a consumer receives rather than loading the checkout directly, build and globally install the packed tarball:
+
+```bash
+package_tarball="$(npm pack --silent --ignore-scripts)"
+npm install --global "./${package_tarball}"
+```
+
+Exercise the pinned OMP compatibility target in an isolated runtime:
+
+```bash
+npm install --global "@oh-my-pi/pi-coding-agent@17.0.3"
+GSD_OMP_BIN=gsd-omp OMP_VERSION=17.0.3 node scripts/host-smoke.cjs
+```
+
+Repeat with the moving host channel:
+
+```bash
+npm install --global "@oh-my-pi/pi-coding-agent@latest"
+GSD_OMP_BIN=gsd-omp OMP_VERSION=latest node scripts/host-smoke.cjs
+```
+
+`scripts/host-smoke.cjs` creates and removes its own temporary `PI_CODING_AGENT_DIR`, installs with `--json`, checks the EoS protocol/core range, validates `doctor` and `descriptor`, launches OMP in RPC mode, checks representative extension commands, and uninstalls the projection. It supplies a placeholder `OPENAI_API_KEY` when one is not present; the smoke test does not require a real key for these startup and state checks.
+
+The compatibility boundary is intentional. OMP `17.0.3` has no `goal_updated` event, so the extension must remain loadable without Goal Mode. Newer OMP hosts may expose Goal Mode. For non-17 hosts, the smoke script retries OMP with an explicit `--tools read,write,gsd_invoke` selection when the tool is not in the default active set, then requires `gsd_invoke` to be discoverable.
+
+## Code layout
+
+```text
+bin/gsd-omp.cjs          Global installer, updater, doctor, descriptor, and argument parser
+src/eos.cjs              Protocol-v1 EoS handshake and OMP adapter construction
+src/extension.cjs        OMP ExtensionAPI commands, tools, events, status, and Goal Mode bridge
+src/projection.cjs       Runtime path rewriting and agent/skill projection
+src/locale.cjs           POSIX locale detection and message lookup
+src/locales/*.cjs        English and Simplified-Chinese CLI dictionaries
+src/gsd-graphify-worker.cjs
+                          Detached graphify worker used by the extension
+scripts/host-smoke.cjs   Isolated packed-install and OMP RPC smoke test
+scripts/bump-version.cjs Release-version metadata updater
+ test/*.test.cjs         Node built-in unit and contract tests
+```
+
+The CLI resolves the installed GSD Core package, builds an EoS binding, and writes an extension wrapper plus projected agents and skills. `src/extension.cjs` is loaded by OMP and delegates orchestration to OMP's native task/event surfaces; it does not patch GSD Core. `src/projection.cjs` rewrites runtime paths and command names so projected content points at the selected OMP root.
+
+## Pull requests and protected `main`
+
+`main` is protected by the repository's `Protect main` ruleset with pull requests and required status checks. Treat direct pushes to `main` as unavailable: develop on a branch, open a pull request, and wait for CI before merge.
+
+A useful PR validation sequence is:
+
+```bash
+npm ci
+npm run lint
+npm test
+```
+
+For changes to installation, projection, extension registration, or host compatibility, also run the packed host smoke against both `17.0.3` and `latest` as shown above. The CI checks that gate the host are the Node 24 unit job and the two-version host-smoke matrix.
+
+## Release workflow
+
+`.github/workflows/release.yml` runs on every push to `main`. Its behavior is automated:
+
+1. Read `package.json`, the latest release tag, and any tag exactly at `HEAD`.
+2. If `HEAD` already has the current version tag, do nothing. If the package version is already ahead of the latest tag, tag that version; otherwise increment the patch version.
+3. For a bump, create or update `chore/release-v<version>`, run `node scripts/bump-version.cjs <semver>`, commit the package/lockfile/README URL changes, and open or update a PR targeting `main`.
+4. Wait for the PR's CI status. The workflow merges a clean release PR (or waits for required approval when GitHub marks a run `action_required`).
+5. Tag the resulting commit as `v<version>` and create the GitHub release. That release is the source used by `gsd-omp update`.
+
+The release job currently sets up Node.js `22.x` in its workflow, while the package's runtime engine remains Node.js `>=24.0.0`; local development and CI should use Node 24 or newer. Do not hand-edit generated release metadata in a feature PR; the release workflow and `scripts/bump-version.cjs` keep `package.json`, `package-lock.json`, and the two README install URLs aligned.
+
+## Related guides
+
+- [Getting Started](GETTING-STARTED.md) — install and operate a released plugin.
+- [Testing](TESTING.md) — test coverage and diagnosis.
+- [Configuration](CONFIGURATION.md) — installer flags, environment variables, and ownership behavior.
+- [Project README](../README.md) — public command surface and EoS contract.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,0 +1,152 @@
+<!-- generated-by: gsd-doc-writer -->
+# Getting Started
+
+`gsd-omp` is an Oh My Pi (OMP) host plugin that exposes the GSD orchestration commands, projected agents and skills, and the native OMP status surface in an OMP session.
+
+For the architecture and runtime boundaries, see [Architecture](ARCHITECTURE.md). For the complete environment and flag reference, see [Configuration](CONFIGURATION.md).
+
+## Prerequisites
+
+- Node.js `>=24.0.0`.
+- Oh My Pi with native `ExtensionAPI` support. The repository's CI exercises OMP `17.0.3` and `latest`.
+- GSD Core `>=1.11.0`. The compatible `@opengsd/gsd-core` dependency (`^1.11.0`) is installed with `gsd-omp`.
+- A project directory in which GSD can create its `.planning/` state when you start a GSD workflow.
+
+## Installation
+
+Install the released plugin globally. Version `1.0.20` is the current release described by this repository:
+
+```bash
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.20.tar.gz
+```
+
+If OMP is not already installed, install a host version covered by the compatibility checks (the pinned fallback is OMP `17.0.3`):
+
+```bash
+npm install --global "@oh-my-pi/pi-coding-agent@17.0.3"
+```
+
+Set `PI_CODING_AGENT_DIR` before projection when you want a non-default OMP runtime root. Without it, the installer uses `~/.omp/agent`.
+
+```bash
+export PI_CODING_AGENT_DIR="$HOME/.omp/agent"
+gsd-omp install
+```
+
+`gsd-omp install` writes the managed extension, projected GSD agents and skills, and `.gsd-omp-manifest.json` below that runtime root. If `GSD_AGENTS_DIR` is already set, the in-session extension preserves that value; otherwise it exposes `<runtime-root>/agents` to GSD Core so agent discovery uses the projected files.
+
+Restart OMP after installation. OMP loads the extension at session startup, so an existing session does not automatically acquire the new commands.
+
+## First run
+
+1. Start or restart OMP in a GSD project.
+2. Check the integration from the shell:
+
+   ```bash
+   gsd-omp doctor
+   gsd-omp descriptor
+   ```
+
+3. In OMP, inspect the project and choose the next action:
+
+   ```text
+   /gsd-status
+   /gsd-next
+   ```
+
+A healthy `doctor` result reports `"ok": true`, profile `programmatic-cli`, protocol version `1`, and no missing or modified files. `descriptor` reports the same protocol/profile contract without inspecting a particular project.
+
+## OMP compatibility and Goal Mode
+
+The plugin's core integration works on both OMP `17.0.3` and `latest` as exercised by CI. OMP `17.0.3` is the pinned fallback when a newer host introduces an incompatible extension change.
+
+Goal Mode is optional host capability, not a prerequisite:
+
+- Hosts that emit OMP's `goal_updated` event (newer hosts, including a compatible `latest`) are mirrored in `/gsd-status`, the footer, widget, and overlay. The latest state can be restored from the OMP session journal.
+- OMP `17.0.3` has no `goal_updated` event. The extension catches that registration failure and keeps commands, tools, status, projection, and the rest of the GSD integration active.
+- While a Goal Mode objective is active, `gsd-omp` leaves the pending GSD next action in place and does not start a competing continuation loop. Run `/goal pause` or `/goal drop`, then run `/gsd-next`.
+
+The plugin does not take over OMP's GoalRuntime; it only consumes the optional event and session-journal state when the host provides them.
+
+## Upgrade
+
+The update command checks the latest GitHub release, globally installs its tarball, and re-projects the managed files:
+
+```bash
+gsd-omp update
+```
+
+Restart OMP after a successful update. If the release check cannot reach GitHub, use the explicit release URL and re-project:
+
+```bash
+gsd-omp uninstall
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.20.tar.gz
+gsd-omp install
+```
+
+The update upgrades the plugin's bundled GSD Core dependency. It does not update an OMP-managed engine tree; use OMP's own update path for the host itself.
+
+## Uninstall
+
+Remove managed projections before removing the global installer:
+
+```bash
+gsd-omp uninstall
+npm uninstall --global gsd-omp
+```
+
+The installer is ownership-aware. It preserves files that were changed after installation and reports them as skipped. To intentionally replace or remove a modified GSD-owned projection, pass `--force`:
+
+```bash
+gsd-omp install --force
+gsd-omp uninstall --force
+```
+
+Use `--force` only when the local changes are disposable.
+
+## Common troubleshooting
+
+### `doctor` reports missing or modified files
+
+Run the JSON form to see the exact runtime root and paths:
+
+```bash
+gsd-omp doctor --json
+```
+
+Confirm that `PI_CODING_AGENT_DIR` is the same value used during installation, then restart OMP. A modified managed file is intentionally not overwritten; inspect or preserve the local edit, or deliberately re-project with `gsd-omp install --force`.
+
+### GSD reports that agents are missing
+
+`PI_CODING_AGENT_DIR` controls where the installer writes projections, while `GSD_AGENTS_DIR` controls where GSD Core searches. If you manage the projection yourself, export the agents directory before starting OMP:
+
+```bash
+export GSD_AGENTS_DIR="${PI_CODING_AGENT_DIR:-$HOME/.omp/agent}/agents"
+```
+
+Then restart OMP and run `/gsd-status` again. Do not point `GSD_AGENTS_DIR` at a directory that does not contain the projected `gsd-*.md` files.
+
+### Goal Mode commands or status are unavailable
+
+This is expected on OMP `17.0.3`: Goal Mode is optional and depends on `goal_updated`. The GSD commands remain usable; run `/gsd-status` and `/gsd-next` normally. On a newer host, pause or drop an active objective before asking GSD to continue:
+
+```text
+/goal pause
+/gsd-next
+```
+
+### `update` cannot check a release
+
+The update command uses the GitHub release metadata. If that check fails, follow the manual uninstall/install sequence above, then run `gsd-omp doctor` and restart OMP.
+
+### The extension is not visible after installing
+
+OMP reads extensions at startup. Restart OMP, confirm `gsd-omp install` targeted the intended `PI_CODING_AGENT_DIR`, and use `gsd-omp descriptor` to confirm the local CLI's protocol declaration.
+
+## Next steps
+
+- [Configuration](CONFIGURATION.md) — environment variables, CLI flags, ownership, and Goal Mode coordination.
+- [Architecture](ARCHITECTURE.md) — module boundaries, projection, and OMP integration.
+- [Development](DEVELOPMENT.md) — local changes, packaging, and host smoke checks.
+- [Testing](TESTING.md) — unit tests, host validation, CI matrix, and failure diagnosis.
+- [Project README](../README.md) — command catalog and EoS contract.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,145 @@
+<!-- generated-by: gsd-doc-writer -->
+# Testing
+
+`gsd-omp` uses Node.js's built-in test runner for unit and contract tests, plus an isolated host smoke test that loads the packed package into OMP. The contributor workflow is described in [Development](DEVELOPMENT.md); user-facing verification is in [Getting Started](GETTING-STARTED.md).
+
+## Test framework and setup
+
+The test command in `package.json` is:
+
+```bash
+node --test
+```
+
+No separate test framework or global setup is required. Install dependencies first with Node.js `>=24.0.0`:
+
+```bash
+npm ci
+```
+
+The test files are under `test/` and use `node:test` plus `node:assert/strict`. Tests create temporary directories and remove them in cleanup, so they do not require a project `.planning/` directory or a configured OMP profile.
+
+## Running tests
+
+Run the complete unit/contract suite:
+
+```bash
+npm test
+```
+
+Run syntax checks (the same command used by CI and `prepack`):
+
+```bash
+npm run lint
+```
+
+Run one focused suite when iterating:
+
+```bash
+node --test test/installer.test.cjs
+node --test test/eos.test.cjs
+node --test test/projection.test.cjs
+node --test test/locale.test.cjs
+node --test test/extension.test.cjs
+```
+
+`test/release-metadata.test.cjs` is included by `npm test` and checks release/version metadata consistency.
+
+## What the unit tests cover
+
+### Installer ownership and rollback
+
+`test/installer.test.cjs` verifies that installation creates the extension, projected agents, skills, and ownership manifest; `doctor` sees a healthy projection; and uninstall removes exactly the owned artifacts. It also covers stale legacy extension cleanup, refusal to overwrite modified or unmanaged files, `--force`-relevant ownership behavior, malformed release metadata, unsafe manifest paths, directory placeholders, symlinked parents, stale projection refresh, and transaction rollback/preservation behavior.
+
+The expected healthy path is protocol version `1`, more than 50 projected artifacts, `doctor.ok === true`, empty `missing`/`modified`, and an uninstall with no skipped paths.
+
+### EoS handshake
+
+`test/eos.test.cjs` checks the OMP binding's protocol-v1 negotiation: profile `programmatic-cli`, imperative adapter, runtime `omp`, passive model routing, host hook bus, filesystem state, native-extension transport, Bun runtime declaration, and no negotiation warnings.
+
+### Projection
+
+`test/projection.test.cjs` checks safe runtime-path rewriting, literal dollar preservation, idempotent skill projection, configured agent-directory use, deterministic artifact filtering/order, command rewriting, and retention of the executor result protocol in projected output.
+
+### Locale
+
+`test/locale.test.cjs` checks the frozen public locale API, `zh*` normalization to `zh-CN`, English fallback, environment precedence (`GSD_OMP_LOCALE` → `LC_ALL` → `LC_MESSAGES` → `LANG`), placeholder interpolation, dictionary fallback, and English/Chinese key and placeholder parity.
+
+### Extension and Goal Mode
+
+`test/extension.test.cjs` exercises native renderers and status updates, continuation choices, resource discovery, context/job status, native session controls, and command registration. Its Goal Mode cases verify that:
+
+- `goal_updated` updates status, widget, objective, and token budget;
+- the latest Goal Mode state can be restored from the OMP session journal;
+- an active objective keeps the pending GSD continuation action without opening a competing selector;
+- stopping GSD reports the active objective rather than falsely claiming the session is idle; and
+- rejecting `goal_updated` registration (the OMP 17 behavior) does not prevent the extension from loading its other events and tools.
+
+`test/release-metadata.test.cjs` ensures `package-lock.json` and both README release install/upgrade URLs use the package version.
+
+## Host smoke test
+
+The host test must use a packed global plugin and an OMP host. The same sequence is used by CI:
+
+```bash
+npm ci
+npm install --global "@oh-my-pi/pi-coding-agent@17.0.3"
+package_tarball="$(npm pack --silent --ignore-scripts)"
+npm install --global "./${package_tarball}"
+GSD_OMP_BIN=gsd-omp OMP_VERSION=17.0.3 node scripts/host-smoke.cjs
+```
+
+Repeat the host steps with `@latest` and `OMP_VERSION=latest`:
+
+```bash
+npm install --global "@oh-my-pi/pi-coding-agent@latest"
+GSD_OMP_BIN=gsd-omp OMP_VERSION=latest node scripts/host-smoke.cjs
+```
+
+The script creates an isolated temporary runtime root, so the smoke test does not modify the developer's normal `~/.omp/agent`. It checks:
+
+1. Installer JSON reports protocol `1`, a GSD Core version satisfying the declared `^1.11.0` range, and more than 50 installed artifacts.
+2. `doctor --json` reports `ok: true`, profile `programmatic-cli`, and empty `missing`/`modified` arrays.
+3. `descriptor --json` reports protocol `1`, profile `programmatic-cli`, native-extension transport, and Bun runtime.
+4. OMP reaches `ready` without an `extension_error` and publishes `/gsd`, `/gsd-next`, `/gsd-plan-phase`, and `/gsd-status` from the extension.
+5. `gsd_invoke` is discoverable on non-17 hosts (the script retries with an explicit tool list when needed); OMP 17 is allowed its legacy RPC-tools path.
+6. Uninstall removes every artifact installed by that smoke run without skipped files.
+
+A successful run ends with output shaped like:
+
+```text
+ok host-smoke: OMP 17.0.3 loaded <count> GSD extension commands and <tool surface>
+```
+
+The `<tool surface>` is `gsd_invoke` for a host exposing that tool, or `legacy RPC tools` for the OMP 17 compatibility path.
+
+## CI matrix
+
+`.github/workflows/ci.yml` runs on pushes to `main`, pull requests, the scheduled upstream check, and manual dispatch. The jobs are:
+
+| Job | Runtime/host | Commands and purpose |
+|---|---|---|
+| `unit` | Node.js `24.x` | `npm ci`, `npm run lint`, `npm test` |
+| `host-smoke` | Node.js `24.x`, Bun, OMP `17.0.3` and `latest` | `npm ci`, install each OMP version, `npm pack --silent --ignore-scripts`, global packed install, then `node scripts/host-smoke.cjs` |
+| `upstream-report` | Scheduled failures only | Opens or updates an upstream-drift issue with the OMP and GSD Core versions and failing smoke context. |
+
+The host matrix is `fail-fast: false`, so pinned and latest compatibility results are reported independently. The smoke job requires the unit job first.
+
+## Diagnosing failures
+
+- **Syntax or unit failure:** run `npm run lint`, then the focused `node --test test/<suite>.test.cjs` command. Read the first failing assertion; the suite names above identify the contract being exercised.
+- **Installer/ownership failure:** run `gsd-omp doctor --json` against the same runtime root used for the install. Check `missing`, `modified`, and `root`; do not use `--force` until you have decided whether local edits should be replaced.
+- **EoS failure:** run `gsd-omp descriptor --json`. Protocol must be `1` and profile must be `programmatic-cli`; an unsupported GSD Core version or SDK negotiation error points to the installed dependency rather than an OMP session.
+- **Projection failure:** inspect the focused projection suite and the generated runtime paths. The installer must keep the manifest inside the selected runtime root and must not follow symlinked parents.
+- **OMP 17 host failure:** verify the pinned host was installed as `@oh-my-pi/pi-coding-agent@17.0.3`. Goal Mode is not expected there; absence of `goal_updated` must not be reported as an extension error.
+- **Latest host failure:** inspect the RPC frames and `available_commands_update` in the smoke output. The script explicitly retries with `--tools read,write,gsd_invoke` for newer hosts whose default active tool set omits `gsd_invoke`. If both attempts fail, compare the host contract with the assertions in `scripts/host-smoke.cjs`.
+- **Network/release failure:** `gsd-omp update` depends on GitHub release metadata. For a local smoke run, install the packed tarball as shown above; this separates package/host failures from release lookup failures.
+
+Do not treat the OMP 17 Goal Mode fallback as a failed test: the required result is a loadable extension with the normal GSD command and status surfaces, without the optional `goal_updated` integration.
+
+## Related guides
+
+- [Development](DEVELOPMENT.md) — packaging and local host validation.
+- [Configuration](CONFIGURATION.md) — runtime roots, environment variables, and installer flags.
+- [Getting Started](GETTING-STARTED.md) — end-user install and verification.
+- [Project README](../README.md) — public commands and compatibility contract.


### PR DESCRIPTION
## Summary
- add the canonical CHANGELOG.md
- add architecture, configuration, getting-started, development, testing, and contributing guides
- link the documentation set from both English and Simplified Chinese READMEs

## Validation
- git diff --check
- Markdown relative-link check (9 files, no broken links)
- npm run lint
- npm test (66 passing)