### PR TITLE
docs: align project metadata and release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Related: [PR #53](https://github.com/tchivs/gsd-omp/pull/53), [release PR #54](h
 
 Related: [PR #51](https://github.com/tchivs/gsd-omp/pull/51), [release PR #52](https://github.com/tchivs/gsd-omp/pull/52).
 
-[Unreleased]: https://github.com/tchivs/gsd-omp/compare/v1.0.20...HEAD
+[Unreleased]: https://github.com/tchivs/gsd-omp/compare/v1.0.21...HEAD
 [1.0.20]: https://github.com/tchivs/gsd-omp/releases/tag/v1.0.20
 [1.0.19]: https://github.com/tchivs/gsd-omp/releases/tag/v1.0.19
 [1.0.18]: https://github.com/tchivs/gsd-omp/releases/tag/v1.0.18

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **English** · [简体中文](./README.zh-CN.md)
 
-`gsd-omp` is an independently maintained Oh My Pi host plugin for the [GSD Embeddable Orchestration System](https://github.com/open-gsd/gsd-core/blob/next/docs/explanation/embeddable-orchestration-system.md). It binds OMP's native extension, command, event, task, and filesystem surfaces to GSD through protocol version 1 of the public Host-Integration SDK.
+`gsd-omp` is an independently maintained Oh My Pi host plugin for the [GSD Embeddable Orchestration System](https://github.com/open-gsd/gsd-core/blob/next/docs/explanation/embeddable-orchestration-system.md). It binds OMP's native extension, command, event, task, and filesystem surfaces to GSD through protocol version 1 of the public Host-Integration SDK. On hosts that expose Goal Mode, it mirrors optional goal state in the GSD status surfaces without taking ownership of OMP's GoalRuntime.
 
 This project is third-party software. It is not endorsed, reviewed, or maintained by OpenGSD.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 [English](./README.md) · **简体中文**
 
-`gsd-omp` 是一个独立维护的 Oh My Pi 宿主插件，面向 [GSD 嵌入式编排系统](https://github.com/open-gsd/gsd-core/blob/next/docs/explanation/embeddable-orchestration-system.md)。它通过公共 Host-Integration SDK 的协议版本 1，将 OMP 原生的扩展、命令、事件、任务与文件系统接口绑定到 GSD。
+`gsd-omp` 是一个独立维护的 Oh My Pi 宿主插件，面向 [GSD 嵌入式编排系统](https://github.com/open-gsd/gsd-core/blob/next/docs/explanation/embeddable-orchestration-system.md)。它通过公共 Host-Integration SDK 的协议版本 1，将 OMP 原生的扩展、命令、事件、任务与文件系统接口绑定到 GSD。在提供 Goal Mode 的主机上，它会把可选的目标状态同步到 GSD 状态界面，但不会接管 OMP 的 GoalRuntime。
 
 本项目为第三方软件，未由 OpenGSD 背书、审查或维护。
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 
 ## Scope
 
-This document describes the runtime architecture of `gsd-omp` v1.0.20: the installer and managed-file manifest, the GSD Embeddable Orchestration System (EoS) handshake, projection of GSD Core artifacts into an Oh My Pi (OMP) profile, the OMP extension lifecycle, localization, and the test/host-smoke boundaries. It is intended for maintainers tracing a change from the package entry point to an OMP session. It does not define GSD Core workflows or replace the authoritative command/skill content shipped by `@opengsd/gsd-core`.
+This document describes the runtime architecture of `gsd-omp`: the installer and managed-file manifest, the GSD Embeddable Orchestration System (EoS) handshake, projection of GSD Core artifacts into an Oh My Pi (OMP) profile, the OMP extension lifecycle, localization, and the test/host-smoke boundaries. It is intended for maintainers tracing a change from the package entry point to an OMP session. It does not define GSD Core workflows or replace the authoritative command/skill content shipped by `@opengsd/gsd-core`.
 
 Relevant implementation paths:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3,7 +3,7 @@
 
 ## Scope
 
-This document covers configuration that affects the `gsd-omp` installer and its OMP extension: runtime-root selection, projected-agent lookup, shell and project-session localization, installer arguments, manifest ownership, and optional OMP Goal Mode coordination. It targets maintainers and operators of `gsd-omp` v1.0.20. GSD Core's complete project configuration schema remains owned by `@opengsd/gsd-core`; only fields read by this plugin are described here.
+This document covers configuration that affects the `gsd-omp` installer and its OMP extension: runtime-root selection, projected-agent lookup, shell and project-session localization, installer arguments, manifest ownership, and optional OMP Goal Mode coordination. It targets maintainers and operators of the current `gsd-omp` release. GSD Core's complete project configuration schema remains owned by `@opengsd/gsd-core`; only fields read by this plugin are described here.
 
 Relevant implementation paths:
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -14,10 +14,10 @@ For the architecture and runtime boundaries, see [Architecture](ARCHITECTURE.md)
 
 ## Installation
 
-Install the released plugin globally. Version `1.0.20` is the current release described by this repository:
+Install the latest released plugin globally:
 
 ```bash
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.20.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.21.tar.gz
 ```
 
 If OMP is not already installed, install a host version covered by the compatibility checks (the pinned fallback is OMP `17.0.3`):
@@ -80,7 +80,7 @@ Restart OMP after a successful update. If the release check cannot reach GitHub,
 
 ```bash
 gsd-omp uninstall
-npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.20.tar.gz
+npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v1.0.21.tar.gz
 gsd-omp install
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gsd-omp",
   "version": "1.0.21",
-  "description": "Oh My Pi host plugin for the GSD Embeddable Orchestration System — extension bindings, slash-command surface, and Host-Integration SDK adapter for AI coding agents",
+  "description": "Oh My Pi host plugin for the GSD Embeddable Orchestration System — extension bindings, slash-command surface, Host-Integration SDK adapter, and optional Goal Mode status integration for AI coding agents",
   "license": "MIT",
   "author": "tchivs",
   "type": "commonjs",
@@ -13,7 +13,10 @@
     "src",
     "README.md",
     "README.zh-CN.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "docs"
   ],
   "scripts": {
     "lint": "node --check bin/gsd-omp.cjs && node --check src/eos.cjs && node --check src/extension.cjs && node --check src/gsd-graphify-worker.cjs && node --check src/locale.cjs && node --check src/locales/en.cjs && node --check src/locales/zh-CN.cjs && node --check src/projection.cjs",
@@ -40,6 +43,7 @@
     "omp",
     "oh-my-pi",
     "eos",
+    "goal-mode",
     "host-plugin",
     "orchestration",
     "embeddable",

--- a/scripts/bump-version.cjs
+++ b/scripts/bump-version.cjs
@@ -1,7 +1,8 @@
 'use strict';
 
-// Bump gsd-omp's version across package.json, package-lock.json, and both
-// README install URLs. Idempotent: running with the current version is a no-op.
+// Bump gsd-omp's version across package.json, package-lock.json, install docs,
+// README URLs, and the changelog compare link. Idempotent: running with the
+// current version is a no-op.
 //
 // Usage: node scripts/bump-version.cjs <semver>
 
@@ -26,11 +27,11 @@ if (pkg.version === version) {
   process.exit(0);
 }
 
-const readmes = ['README.md', 'README.zh-CN.md'];
-for (const readme of readmes) {
-  const p = path.join(root, readme);
+const versionedInstallDocs = ['README.md', 'README.zh-CN.md', 'docs/GETTING-STARTED.md'];
+for (const document of versionedInstallDocs) {
+  const p = path.join(root, document);
   if (!/v\d+\.\d+\.\d+\.tar\.gz/.test(fs.readFileSync(p, 'utf8'))) {
-    console.error(`no versioned install URL found in ${readme}`);
+    console.error(`no versioned install URL found in ${document}`);
     process.exit(1);
   }
 }
@@ -42,10 +43,19 @@ if (lock.packages && lock.packages['']) lock.packages[''].version = version;
 fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
 
-for (const readme of readmes) {
-  const p = path.join(root, readme);
+for (const document of versionedInstallDocs) {
+  const p = path.join(root, document);
   const text = fs.readFileSync(p, 'utf8');
   fs.writeFileSync(p, text.replace(/v\d+\.\d+\.\d+\.tar\.gz/g, `v${version}.tar.gz`));
+}
+
+const changelogPath = path.join(root, 'CHANGELOG.md');
+if (fs.existsSync(changelogPath)) {
+  const text = fs.readFileSync(changelogPath, 'utf8');
+  fs.writeFileSync(changelogPath, text.replace(
+    /(\[Unreleased\]:\s+https:\/\/github\.com\/tchivs\/gsd-omp\/compare\/v)\d+\.\d+\.\d+(\.\.\.HEAD)/,
+    `$1${version}$2`,
+  ));
 }
 
 console.log(`bumped to ${version}`);

--- a/test/release-metadata.test.cjs
+++ b/test/release-metadata.test.cjs
@@ -11,7 +11,7 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(path.join(root, file), 'utf8'));
 }
 
-test('release metadata and README install commands use the package version', () => {
+test('release metadata and install documentation use the package version', () => {
   const packageJson = readJson('package.json');
   const packageLock = readJson('package-lock.json');
   const expectedInstall = `npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v${packageJson.version}.tar.gz`;
@@ -19,15 +19,22 @@ test('release metadata and README install commands use the package version', () 
   assert.equal(packageLock.version, packageJson.version, 'package-lock.json version must match package.json');
   assert.equal(packageLock.packages[''].version, packageJson.version, 'lockfile root package version must match package.json');
 
-  for (const readme of ['README.md', 'README.zh-CN.md']) {
-    const installCommands = fs.readFileSync(path.join(root, readme), 'utf8')
+  const versionedInstallDocs = ['README.md', 'README.zh-CN.md', 'docs/GETTING-STARTED.md'];
+  for (const document of versionedInstallDocs) {
+    const installCommands = fs.readFileSync(path.join(root, document), 'utf8')
       .split(/\r?\n/)
       .filter((line) => line.startsWith('npm install --global https://github.com/tchivs/gsd-omp/archive/refs/tags/v'));
 
     assert.deepEqual(
       installCommands,
       [expectedInstall, expectedInstall],
-      `${readme} install and upgrade commands must both use v${packageJson.version}`,
+      `${document} install and upgrade commands must both use v${packageJson.version}`,
     );
   }
+
+  const changelog = fs.readFileSync(path.join(root, 'CHANGELOG.md'), 'utf8');
+  assert.ok(
+    changelog.includes(`[Unreleased]: https://github.com/tchivs/gsd-omp/compare/v${packageJson.version}...HEAD`),
+    'CHANGELOG.md Unreleased compare link must use the package version',
+  );
 });


### PR DESCRIPTION
## Summary
- mention optional Goal Mode support in package and README descriptions
- add the `goal-mode` package keyword and GitHub repository topic
- include project documentation in packed artifacts
- keep Getting Started install URLs and CHANGELOG compare links aligned during automated version bumps

## Validation
- npm run lint
- npm test (66 passing)
- npm pack --dry-run --json includes all documentation
- isolated bump-version fixture test
- Markdown relative-link check