### PR TITLE
fix: sync GSD Core 1.12.0 and stale projection updates

### DIFF
--- a/bin/gsd-omp.cjs
+++ b/bin/gsd-omp.cjs
@@ -197,9 +197,16 @@ function update({ root: rootOverride, force = false, latestRelease, json = false
   const release = typeof provider === 'function' ? provider() : null;
   const latest = normalizedReleaseVersion(release?.tag_name);
   if (!latest) throw new Error(t('cli.error.updateCheckFailed'));
+  const root = runtimeRoot(rootOverride);
+  const manifest = readManifest(root);
+  const projectionStale = manifest?.version !== packageJson.version;
   const comparison = compareVersions(latest, packageJson.version);
-  if (comparison <= 0) {
-    return { upToDate: comparison === 0, current: packageJson.version, latest, root: runtimeRoot(rootOverride) };
+  if (comparison <= 0 && !projectionStale) {
+    return { upToDate: comparison === 0, current: packageJson.version, latest, root };
+  }
+  if (comparison <= 0 && projectionStale) {
+    install({ root: rootOverride, force });
+    return { updated: true, from: manifest?.version || null, to: packageJson.version, root };
   }
   const tarball = release.tarball_url || `https://github.com/${GITHUB_REPO}/archive/refs/tags/v${latest}.tar.gz`;
   const npmArgs = ['install', '--global', tarball];
@@ -219,7 +226,7 @@ function update({ root: rootOverride, force = false, latestRelease, json = false
   if (force) installArgs.push('--force');
   const projection = spawnSync(cli, installArgs, { encoding: 'utf8', stdio: json ? ['ignore', 'ignore', 'inherit'] : 'inherit', timeout: 120000 });
   if (projection.status !== 0) throw new Error(t('cli.error.updateProjectionFailed'));
-  return { updated: true, from: packageJson.version, to: latest, root: runtimeRoot(rootOverride) };
+  return { updated: true, from: packageJson.version, to: latest, root };
 }
 
 function compareVersions(left, right) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.23",
       "license": "MIT",
       "dependencies": {
-        "@opengsd/gsd-core": "^1.11.0"
+        "@opengsd/gsd-core": "^1.12.0"
       },
       "bin": {
         "gsd-omp": "bin/gsd-omp.cjs"
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@opengsd/gsd-core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@opengsd/gsd-core/-/gsd-core-1.11.0.tgz",
-      "integrity": "sha512-z1RLWsQshYViJIk94SB0x9/AYPykj5LIuLxwjS0s+WgaCBgVtTknCsVR3x4itrBeqmiUEvGiN6cO/bOay0zOiQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opengsd/gsd-core/-/gsd-core-1.12.0.tgz",
+      "integrity": "sha512-fMjtqWQLJooD9HrkRLsfwmVmKwLN96Lea3TKTPhFl0CZ9ZFsv4Dr5f/vB0TxIgR1Hm2MgzkeMynS0MQy382N5A==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepack": "npm run lint && npm test"
   },
   "dependencies": {
-    "@opengsd/gsd-core": "^1.11.0"
+    "@opengsd/gsd-core": "^1.12.0"
   },
   "engines": {
     "node": ">=24.0.0",

--- a/test/installer.test.cjs
+++ b/test/installer.test.cjs
@@ -78,16 +78,45 @@ test('removes the stale legacy CJS extension during reinstall', () => {
   }
 });
 
- test('update reports up-to-date when the local version matches the latest GitHub release', () => {
+test('update reports up-to-date when the local version matches the latest GitHub release', () => {
   const packageJson = require('../package.json');
-  const { update } = require('../bin/gsd-omp.cjs');
-  // Inject a stub instead of hitting the live GitHub API.
-  const result = update({
-    root: temporaryRoot('gsd-omp-update'),
-    latestRelease: () => ({ tag_name: `v${packageJson.version}`, tarball_url: 'https://api.github.com/repos/tchivs/gsd-omp/tarball/x' }),
-  });
-  assert.equal(result.upToDate, true);
-  assert.equal(result.current, packageJson.version);
+  const root = temporaryRoot('gsd-omp-update');
+  try {
+    install({ root });
+    // Inject a stub instead of hitting the live GitHub API.
+    const result = update({
+      root,
+      latestRelease: () => ({ tag_name: `v${packageJson.version}`, tarball_url: 'https://api.github.com/repos/tchivs/gsd-omp/tarball/x' }),
+    });
+    assert.equal(result.upToDate, true);
+    assert.equal(result.current, packageJson.version);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('refreshes a stale runtime projection when the package matches the latest release', () => {
+  const packageJson = require('../package.json');
+  const root = temporaryRoot('gsd-omp-stale-update');
+  try {
+    install({ root });
+    const manifestPath = path.join(root, '.gsd-omp-manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.version = '1.0.18';
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const result = update({
+      root,
+      latestRelease: () => ({ tag_name: `v${packageJson.version}` }),
+    });
+
+    assert.equal(result.updated, true);
+    assert.equal(result.from, '1.0.18');
+    assert.equal(JSON.parse(fs.readFileSync(manifestPath, 'utf8')).version, packageJson.version);
+    assert.equal(doctor({ root }).version, packageJson.version);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 test('compares semantic release versions numerically', () => {
   assert.equal(compareVersions('1.0.15', '1.0.12') > 0, true);


### PR DESCRIPTION
## Summary
- refresh stale runtime projections when `update` finds the local package current
- add regression coverage for stale manifest versions
- sync `@opengsd/gsd-core` to 1.12.0
- verify OMP 17.0.3 and 18.1.4 host compatibility

## Verification
- `npm run lint`
- `npm test` (67 passing)
- OMP 17.0.3 host-smoke
- OMP 18.1.4 host-smoke